### PR TITLE
generate-directory.sh uses nix-shell --pure

### DIFF
--- a/generate-directory.sh
+++ b/generate-directory.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=./nix -i bash -p python36Packages.jupyterlab
+#! nix-shell --pure -I nixpkgs=./nix -i bash -p python36Packages.jupyterlab -p nodejs
 
 if [ $# -eq 0 ]
   then


### PR DESCRIPTION
This also adds the missing nodejs package (npm is required).