### PR TITLE
monad-bayes example

### DIFF
--- a/example/Haskell/bayesMonad/dice_example.ipynb
+++ b/example/Haskell/bayesMonad/dice_example.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# monad-bayes example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-- A toy model for dice rolling from http://dl.acm.org/citation.cfm?id=2804317\n",
+    "-- Exact results can be obtained using Dist monad\n",
+    "\n",
+    "import Control.Monad (liftM2)\n",
+    "import Control.Monad.IO.Class (liftIO)\n",
+    "import Control.Monad.Bayes.Class\n",
+    "import Control.Monad.Bayes.Sampler\n",
+    "import Control.Monad.Bayes.Population\n",
+    "import Control.Monad.Bayes.Inference.SMC\n",
+    "\n",
+    "-- | A toss of a six-sided die.\n",
+    "die :: MonadSample m => m Int\n",
+    "die = uniformD [1..6]\n",
+    "\n",
+    "-- | A sum of outcomes of n independent tosses of six-sided dice.\n",
+    "dice :: MonadSample m => Int -> m Int\n",
+    "dice 1 = die\n",
+    "dice n = liftM2 (+) die (dice (n-1))\n",
+    "\n",
+    "-- | Toss of two dice where the output is greater than 4.\n",
+    "dice_hard :: MonadInfer m => m Int\n",
+    "dice_hard = do\n",
+    "  result <- dice 2\n",
+    "  condition (result > 4)\n",
+    "  return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3,0.0)\n",
+       "(7,9.999999999999998e-2)\n",
+       "(10,9.999999999999998e-2)\n",
+       "(6,9.999999999999998e-2)\n",
+       "(7,9.999999999999998e-2)\n",
+       "(9,9.999999999999998e-2)\n",
+       "(5,9.999999999999998e-2)\n",
+       "(7,9.999999999999998e-2)\n",
+       "(6,9.999999999999998e-2)\n",
+       "(8,9.999999999999998e-2)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sampleIOfixed $ do\n",
+    "  res <- runPopulation $ smcMultinomial 0 10 dice_hard\n",
+    "  liftIO $ putStr $ unlines $ map show res"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Haskell - bayes-monad",
+   "language": "haskell",
+   "name": "ihaskell_bayes-monad"
+  },
+  "language_info": {
+   "codemirror_mode": "ihaskell",
+   "file_extension": ".hs",
+   "name": "haskell",
+   "pygments_lexer": "Haskell",
+   "version": "8.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example/Haskell/bayesMonad/shell.nix
+++ b/example/Haskell/bayesMonad/shell.nix
@@ -1,0 +1,41 @@
+let
+  jupyterLibPath = ../../..;
+  nixpkgsPath = jupyterLibPath + "/nix";
+
+  pkgs = import nixpkgsPath {};
+  monadBayesSrc = pkgs.fetchFromGitHub {
+    owner = "adscib";
+    repo = "monad-bayes";
+    rev = "647ba7cb5a98ae028600f3d828828616891b40fb";
+    sha256 = "1z4i03idsjnxqds3b5zk52gic2m8zflhh2v64yp11k0idxggiv2d";
+  };
+
+  haskellPackages = pkgs.haskellPackages.override (old: {
+    overrides = pkgs.lib.composeExtensions old.overrides
+        (self: hspkgs: {
+          monad-bayes = hspkgs.callCabal2nix "monad-bayes" "${monadBayesSrc}" {};
+        });
+      });
+
+  jupyter = import jupyterLibPath { pkgs=pkgs; };
+
+  ihaskellWithPackages = jupyter.kernels.iHaskellWith {
+      #extraIHaskellFlags = "--debug";
+      haskellPackages=haskellPackages;
+      name = "bayes-monad";
+      packages = p: with p; [
+        monad-bayes
+      ];
+    };
+
+  jupyterlabWithKernels =
+    jupyter.jupyterlabWith {
+      kernels = [ ihaskellWithPackages ];
+      directory = jupyter.mkDirectoryWith {
+        extensions = [
+          "jupyterlab-ihaskell"
+        ];
+      };
+    };
+in
+  jupyterlabWithKernels.env


### PR DESCRIPTION
this example shows how to use a custom override on top of the default overrides using the monad-bayes library https://github.com/adscib/monad-bayes .