### PR TITLE
Elm kernel (fails because of incompatibility with elm 0.19)

### DIFF
--- a/example/Elm/basic/elm_example.ipynb
+++ b/example/Elm/basic/elm_example.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example/Elm/basic/shell.nix
+++ b/example/Elm/basic/shell.nix
@@ -1,0 +1,9 @@
+let
+  jupyterLibPath = ../../..;
+  jupyter = import jupyterLibPath {};
+
+  jupyterlabWithKernels = jupyter.jupyterlabWith {
+      kernels = [ (jupyter.kernels.elmKernel {name="basic";}) ];
+  };
+in
+  jupyterlabWithKernels.env

--- a/kernels/default.nix
+++ b/kernels/default.nix
@@ -11,4 +11,5 @@
   xeusCling = callPackage ./xeus-cling;
   iJavascript = callPackage ./ijavascript;
   gophernotes = callPackage ./gophernotes;
+  elmKernel = callPackage ./elm;
 }

--- a/kernels/elm/default.nix
+++ b/kernels/elm/default.nix
@@ -1,0 +1,41 @@
+{ python3
+, stdenv
+, name ? "nixpkgs"
+, packages ? (_:[])
+}:
+
+let
+  kernelEnv = python3.withPackages (p:
+    packages p ++ (with p; [
+      elm_kernel
+    ])
+  );
+
+  kernelFile = {
+    display_name = "Elm - ${name}";
+    language = "elm";
+    argv = [
+      "${kernelEnv.interpreter}"
+      "-m"
+      "elm_kernel"
+      "-f"
+      "{connection_file}"
+    ];
+    logo64 = "logo-64x64.svg";
+  };
+
+  elmKernel = stdenv.mkDerivation {
+    name = "elm-${name}";
+    src = ./elm.svg;
+    phases = "installPhase";
+    installPhase = ''
+      mkdir -p $out/kernels/elm_${name}
+      cp $src $out/kernels/elm_${name}/logo-64x64.svg
+      echo '${builtins.toJSON kernelFile}' > $out/kernels/elm_${name}/kernel.json
+    '';
+  };
+in
+  {
+    spec = elmKernel;
+    runtimePackages = [];
+  }

--- a/kernels/elm/elm.svg
+++ b/kernels/elm/elm.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 323.141 322.95" enable-background="new 0 0 323.141 322.95" xml:space="preserve">
+<g>
+  <polygon fill="#F0AD00" points="161.649,152.782 231.514,82.916 91.783,82.916"/>
+
+  <polygon fill="#7FD13B" points="8.867,0 79.241,70.375 232.213,70.375 161.838,0"/>
+
+  <rect fill="#7FD13B" x="192.99" y="107.392" transform="matrix(0.7071 0.7071 -0.7071 0.7071 186.4727 -127.2386)" width="107.676" height="108.167"/>
+
+  <polygon fill="#60B5CC" points="323.298,143.724 323.298,0 179.573,0"/>
+
+  <polygon fill="#5A6378" points="152.781,161.649 0,8.868 0,314.432"/>
+
+  <polygon fill="#F0AD00" points="255.522,246.655 323.298,314.432 323.298,178.879"/>
+
+  <polygon fill="#60B5CC" points="161.649,170.517 8.869,323.298 314.43,323.298"/>
+</g>
+</svg>

--- a/nix/python-overlay.nix
+++ b/nix/python-overlay.nix
@@ -1,6 +1,29 @@
 _: pkgs:
 let
   packageOverrides = selfPythonPackages: pythonPackages: {
+    elm_kernel = pythonPackages.buildPythonPackage rec {
+      pname = "elm_kernel";
+      version = "0.2";
+
+      src = pythonPackages.fetchPypi {
+        inherit pname version;
+        sha256 = "0e6eba2c1028abd09a1ca218f331e732702dd266281dd228634fc8a6a1e3b38b";
+      };
+      preBuild = "export HOME=$TEMPDIR";
+      doCheck = false;
+      propagatedBuildInputs = [
+        pythonPackages.jupyter
+        (pkgs.elmPackages.elm.overrideAttrs (_: {
+              version = "0.18.0";
+              src = pkgs.fetchgit {
+                url = "https://github.com/elm/compiler";
+                sha256 = "09fmrbfpc1kzc3p9h79w57b9qjhajdswc4jfm9gyjw95vsiwasgh";
+                rev = "0.18.0";
+                fetchSubmodules = true;
+            };
+           }))
+        ];
+    };
 
     jupyterlab = pythonPackages.jupyterlab.overridePythonAttrs (_:{
       doCheck = false;


### PR DESCRIPTION
the elm_kernel module uses the `elm-make` command that was apparently changed to `elm make` recently.

I tried to override the nixpkgs elm version to become 0.18 but failed. The difficulty is that the elm sources are defined in two places:

the sources are here:
https://github.com/NixOS/nixpkgs/blob/5ec91bac2f58d96528d6afbbb05a788ac40d2768/pkgs/development/compilers/elm/packages/elm.nix

and they are patched here:
https://github.com/NixOS/nixpkgs/blob/c71e6fa79bfe5f1734e161fc9a6b4f9ecc6fac9f/pkgs/development/compilers/elm/default.nix#L17-L22

