### PR TITLE
Compose python/haskell overlays with any overlays that came before.

### DIFF
--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -14,82 +14,87 @@ let
     rev = "3fd4d8d62e12452745dc484459d1a5874f523df9";
     sha256 = "12z0jfhwpvk5gd1wckasy346aqm0280pv5h7jl1grpk797zjdswx";
   };
+
+  overrides = self: hspkgs:
+    let
+      callDisplayPackage = name:
+        hspkgs.callCabal2nix
+          "ihaskell-${name}"
+          "${ihaskellSrc}/ihaskell-display/ihaskell-${name}"
+          {};
+      dontCheck = pkgs.haskell.lib.dontCheck;
+    in
+    {
+      # -- ihaskell overrides
+      # the current version of hlint in nixpkgs uses a different
+      # version of haskell-src-exts, which creates incompatibilities
+      # when building ihaskell
+      hlint = hspkgs.callHackage "hlint" "2.1.11" {};
+      zeromq4-haskell = dontCheck hspkgs.zeromq4-haskell;
+      ihaskell          = pkgs.haskell.lib.overrideCabal (
+                           hspkgs.callCabal2nix "ihaskell" ihaskellSrc {}) (_drv: {
+         preCheck = ''
+           export HOME=$(${pkgs.pkgs.coreutils}/bin/mktemp -d)
+           export PATH=$PWD/dist/build/ihaskell:$PATH
+           export GHC_PACKAGE_PATH=$PWD/dist/package.conf.inplace/:$GHC_PACKAGE_PATH
+         '';
+         configureFlags = (_drv.configureFlags or []) ++ [
+           # otherwise the tests are agonisingly slow and the kernel times out
+           "--enable-executable-dynamic"
+         ];
+         doHaddock = false;
+         });
+      ghc-parser = hspkgs.callCabal2nix "ghc-parser" "${ihaskellSrc}/ghc-parser" {};
+      ipython-kernel = hspkgs.callCabal2nix "ipython-kernel" "${ihaskellSrc}/ipython-kernel" {};
+      ihaskell-aeson = callDisplayPackage "aeson";
+      ihaskell-blaze = callDisplayPackage "blaze";
+      ihaskell-charts = callDisplayPackage "charts";
+      ihaskell-diagrams = callDisplayPackage "diagrams";
+      ihaskell-gnuplot = callDisplayPackage "gnuplot";
+      ihaskell-graphviz = callDisplayPackage "graphviz";
+      ihaskell-hatex = callDisplayPackage "hatex";
+      ihaskell-juicypixels = callDisplayPackage "juicypixels";
+      ihaskell-magic = callDisplayPackage "magic";
+      ihaskell-plot = callDisplayPackage "plot";
+      ihaskell-rlangqq = callDisplayPackage "rlangqq";
+      ihaskell-static-canvas = callDisplayPackage "static-canvas";
+      ihaskell-widgets = callDisplayPackage "widgets";
+
+      # -- dh-core integration
+      # the new datasets module from dh-core doesn't build because one of the
+      # dependencies doesn't build due to a missing dependency. We therefore
+      # use the one that comes with nixpkgs (vs 0.2.5) for now
+      # datasets = hspkgs.callCabal2nix "datasets" "${dataHaskellCoreSrc}/datasets" {};
+      dh-core = hspkgs.callCabal2nix "dh-core" "${dataHaskellCoreSrc}/dh-core" {};
+      analyze = hspkgs.callCabal2nix "analyze" "${dataHaskellCoreSrc}/analyze" {};
+
+      megaparsec = hspkgs.megaparsec_6_5_0;
+
+      # -- missing dependency
+      aeson = pkgs.haskell.lib.addBuildDepends hspkgs.aeson [ self.contravariant ];
+
+      # For Frames
+      # Latest version of singletons incompatible with GHC 8.4.4
+      vinyl_0_10_0 = hspkgs.vinyl_0_10_0_1;
+      singletons = dontCheck (hspkgs.callHackage "singletons" "2.4.1" {});
+      th-desugar = hspkgs.callHackage "th-desugar" "1.8" {};
+
+      # For funflow
+      funflow = pkgs.haskell.lib.dontCheck hspkgs.funflow;
+
+      # For TensorFlow, tests not passing
+      conduit-extra = dontCheck hspkgs.conduit-extra;
+
+      # For diagrams
+      diagrams-contrib = dontCheck hspkgs.diagrams-contrib;
+    };
 in
 
 {
-  haskellPackages = pkgs.haskell.packages.ghc844.override {
-    overrides = self: hspkgs:
-      let
-        callDisplayPackage = name:
-          hspkgs.callCabal2nix
-            "ihaskell-${name}"
-            "${ihaskellSrc}/ihaskell-display/ihaskell-${name}"
-            {};
-        dontCheck = pkgs.haskell.lib.dontCheck;
-      in
-      {
-        # -- ihaskell overrides
-        # the current version of hlint in nixpkgs uses a different
-        # version of haskell-src-exts, which creates incompatibilities
-        # when building ihaskell
-        hlint = hspkgs.callHackage "hlint" "2.1.11" {};
-        zeromq4-haskell = dontCheck hspkgs.zeromq4-haskell;
-        ihaskell          = pkgs.haskell.lib.overrideCabal (
-                             hspkgs.callCabal2nix "ihaskell" ihaskellSrc {}) (_drv: {
-           preCheck = ''
-             export HOME=$(${pkgs.pkgs.coreutils}/bin/mktemp -d)
-             export PATH=$PWD/dist/build/ihaskell:$PATH
-             export GHC_PACKAGE_PATH=$PWD/dist/package.conf.inplace/:$GHC_PACKAGE_PATH
-           '';
-           configureFlags = (_drv.configureFlags or []) ++ [
-             # otherwise the tests are agonisingly slow and the kernel times out
-             "--enable-executable-dynamic"
-           ];
-           doHaddock = false;
-           });
-        ghc-parser = hspkgs.callCabal2nix "ghc-parser" "${ihaskellSrc}/ghc-parser" {};
-        ipython-kernel = hspkgs.callCabal2nix "ipython-kernel" "${ihaskellSrc}/ipython-kernel" {};
-        ihaskell-aeson = callDisplayPackage "aeson";
-        ihaskell-blaze = callDisplayPackage "blaze";
-        ihaskell-charts = callDisplayPackage "charts";
-        ihaskell-diagrams = callDisplayPackage "diagrams";
-        ihaskell-gnuplot = callDisplayPackage "gnuplot";
-        ihaskell-graphviz = callDisplayPackage "graphviz";
-        ihaskell-hatex = callDisplayPackage "hatex";
-        ihaskell-juicypixels = callDisplayPackage "juicypixels";
-        ihaskell-magic = callDisplayPackage "magic";
-        ihaskell-plot = callDisplayPackage "plot";
-        ihaskell-rlangqq = callDisplayPackage "rlangqq";
-        ihaskell-static-canvas = callDisplayPackage "static-canvas";
-        ihaskell-widgets = callDisplayPackage "widgets";
-
-        # -- dh-core integration
-        # the new datasets module from dh-core doesn't build because one of the
-        # dependencies doesn't build due to a missing dependency. We therefore
-        # use the one that comes with nixpkgs (vs 0.2.5) for now
-        # datasets = hspkgs.callCabal2nix "datasets" "${dataHaskellCoreSrc}/datasets" {};
-        dh-core = hspkgs.callCabal2nix "dh-core" "${dataHaskellCoreSrc}/dh-core" {};
-        analyze = hspkgs.callCabal2nix "analyze" "${dataHaskellCoreSrc}/analyze" {};
-
-        megaparsec = hspkgs.megaparsec_6_5_0;
-
-        # -- missing dependency
-        aeson = pkgs.haskell.lib.addBuildDepends hspkgs.aeson [ self.contravariant ];
-
-        # For Frames
-        # Latest version of singletons incompatible with GHC 8.4.4
-        vinyl_0_10_0 = hspkgs.vinyl_0_10_0_1;
-        singletons = dontCheck (hspkgs.callHackage "singletons" "2.4.1" {});
-        th-desugar = hspkgs.callHackage "th-desugar" "1.8" {};
-
-        # For funflow
-        funflow = pkgs.haskell.lib.dontCheck hspkgs.funflow;
-
-        # For TensorFlow, tests not passing
-        conduit-extra = dontCheck hspkgs.conduit-extra;
-
-        # For diagrams
-        diagrams-contrib = dontCheck hspkgs.diagrams-contrib;
-      };
-  };
+  haskellPackages = pkgs.haskell.packages.ghc844.override (old: {
+    overrides = pkgs.lib.
+      pkgs.lib.composeExtensions
+        (old.overrides or (_: _: {}))
+        overrides;
+  });
 }

--- a/nix/python-overlay.nix
+++ b/nix/python-overlay.nix
@@ -196,4 +196,11 @@ let
 
 in
 
-{ python3 = pkgs.python3.override { inherit packageOverrides; }; }
+{
+  python3 = pkgs.python3.override (old: {
+    packageOverrides =
+      pkgs.lib.composeExtensions
+        (old.packageOverrides or (_: _: {}))
+        packageOverrides;
+  });
+}


### PR DESCRIPTION
This allows you to overlay the packages supplied by `jupyterWith` on top of your
own pkgs.

For example:

```nix
let
  jupyterWithSrc = pkgs.fetchFromGitHub {
    owner = "tweag";
    repo = "jupyterWith";
    rev = "...";
    sha256 = "...";
  };

  pythonOverlay =
    import "${jupyterWithSrc}/nix/python-overlay.nix";

  jupyterPkgs =
    pkgs.appendOverlays [ pythonOverlay ];

  jupyterWith =
    import jupyterWithSrc { pkgs = jupyterPkgs; };

```

Note that it's already possible to supply overlays to `jupyterWith`, but it's not the same as this. This is about overlaying jupyter on top of your own package sets rather than about overriding the packages supplied by `jupyterWith`.

(I personally think it would be more friendly if jupyterWith supplied overlays with these renamed to `ipythonPackages` and `ihaskellPackages`. But I didn't want to go nuts, happy to do a quick follow up renaming PR if people are keen on the idea.)