### PR TITLE
Make most overrides local

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{overlays ? []
-, pkgs ? import ./nix {inherit overlays;}
+{ overlays ? []
+, pkgs ? import ./nix { inherit overlays; }
 }:
 
 with (import ./lib/directory.nix { inherit pkgs; });

--- a/example/Haskell/Frames/shell.nix
+++ b/example/Haskell/Frames/shell.nix
@@ -1,8 +1,8 @@
 let
   jupyterLibPath = ../../..;
-  nixpkgsPath = jupyterLibPath + "/nix";
-  pkgs = import nixpkgsPath {};
-  jupyter = import jupyterLibPath { pkgs=pkgs; };
+  jupyter = import jupyterLibPath {
+    overlays = [ (import ./overlay.nix) ];
+  };
 
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       name = "Frames";

--- a/example/Haskell/Funflow/shell.nix
+++ b/example/Haskell/Funflow/shell.nix
@@ -4,10 +4,12 @@ let
   pkgs = import nixpkgsPath {};
   jupyter = import jupyterLibPath { pkgs=pkgs; };
 
+  funflow = pkgs.haskell.lib.dontCheck pkgs.haskellPackages.funflow;
+
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       #extraIHaskellFlags = "--debug";
       name = "Funflow";
-      packages = p: with p; [
+      packages = p: [
         funflow
       ];
     };

--- a/example/Haskell/dataHaskell/shell.nix
+++ b/example/Haskell/dataHaskell/shell.nix
@@ -2,7 +2,20 @@ let
   jupyterLibPath = ../../..;
   nixpkgsPath = jupyterLibPath + "/nix";
   pkgs = import nixpkgsPath {};
-  jupyter = import jupyterLibPath { pkgs=pkgs; };
+  jupyter = import jupyterLibPath {
+    overlays = [ (import ./overlay.nix) ];
+  };
+
+  dataHaskellCoreSrc = pkgs.fetchFromGitHub {
+    owner = "DataHaskell";
+    repo = "dh-core";
+    rev = "3fd4d8d62e12452745dc484459d1a5874f523df9";
+    sha256 = "12z0jfhwpvk5gd1wckasy346aqm0280pv5h7jl1grpk797zjdswx";
+  };
+
+  hspkgs = pkgs.haskellPackages;
+  dh-core = hspkgs.callCabal2nix "dh-core" "${dataHaskellCoreSrc}/dh-core" {};
+  analyze = hspkgs.callCabal2nix "analyze" "${dataHaskellCoreSrc}/analyze" {};
 
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       name = "dataHaskell";

--- a/example/Haskell/diagrams/shell.nix
+++ b/example/Haskell/diagrams/shell.nix
@@ -1,8 +1,8 @@
 let
   jupyterLibPath = ../../..;
-  nixpkgsPath = jupyterLibPath + "/nix";
-  pkgs = import nixpkgsPath {};
-  jupyter = import jupyterLibPath { pkgs=pkgs; };
+  jupyter = import jupyterLibPath {
+    overlays = [ (import ./overlay.nix) ];
+  };
 
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       name = "Frames";

--- a/example/Haskell/tensorflow/shell.nix
+++ b/example/Haskell/tensorflow/shell.nix
@@ -2,7 +2,9 @@ let
   jupyterLibPath = ../../..;
   nixpkgsPath = jupyterLibPath + "/nix";
   pkgs = import nixpkgsPath {};
-  jupyter = import jupyterLibPath { pkgs=pkgs; };
+  jupyter = import jupyterLibPath {
+    overlays = [ (import ./overlay.nix) ];
+  };
 
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       name = "Tensorflow";

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -8,13 +8,6 @@ let
     sha256 = "1v8hvr75lg3353qgm18k43b3wl040zkbhkklw6ygv5w8zzb3x826";
   };
 
-  dataHaskellCoreSrc = pkgs.fetchFromGitHub {
-    owner = "DataHaskell";
-    repo = "dh-core";
-    rev = "3fd4d8d62e12452745dc484459d1a5874f523df9";
-    sha256 = "12z0jfhwpvk5gd1wckasy346aqm0280pv5h7jl1grpk797zjdswx";
-  };
-
   overrides = self: hspkgs:
     let
       callDisplayPackage = name:
@@ -31,18 +24,19 @@ let
       # when building ihaskell
       hlint = hspkgs.callHackage "hlint" "2.1.11" {};
       zeromq4-haskell = dontCheck hspkgs.zeromq4-haskell;
-      ihaskell          = pkgs.haskell.lib.overrideCabal (
-                           hspkgs.callCabal2nix "ihaskell" ihaskellSrc {}) (_drv: {
-         preCheck = ''
-           export HOME=$(${pkgs.pkgs.coreutils}/bin/mktemp -d)
-           export PATH=$PWD/dist/build/ihaskell:$PATH
-           export GHC_PACKAGE_PATH=$PWD/dist/package.conf.inplace/:$GHC_PACKAGE_PATH
-         '';
-         configureFlags = (_drv.configureFlags or []) ++ [
-           # otherwise the tests are agonisingly slow and the kernel times out
-           "--enable-executable-dynamic"
-         ];
-         doHaddock = false;
+      ihaskell = pkgs.haskell.lib.overrideCabal
+        (hspkgs.callCabal2nix "ihaskell" ihaskellSrc {})
+        (_drv: {
+          preCheck = ''
+            export HOME=$(${pkgs.pkgs.coreutils}/bin/mktemp -d)
+            export PATH=$PWD/dist/build/ihaskell:$PATH
+            export GHC_PACKAGE_PATH=$PWD/dist/package.conf.inplace/:$GHC_PACKAGE_PATH
+          '';
+          configureFlags = (_drv.configureFlags or []) ++ [
+            # otherwise the tests are agonisingly slow and the kernel times out
+            "--enable-executable-dynamic"
+          ];
+          doHaddock = false;
          });
       ghc-parser = hspkgs.callCabal2nix "ghc-parser" "${ihaskellSrc}/ghc-parser" {};
       ipython-kernel = hspkgs.callCabal2nix "ipython-kernel" "${ihaskellSrc}/ipython-kernel" {};
@@ -60,33 +54,10 @@ let
       ihaskell-static-canvas = callDisplayPackage "static-canvas";
       ihaskell-widgets = callDisplayPackage "widgets";
 
-      # -- dh-core integration
-      # the new datasets module from dh-core doesn't build because one of the
-      # dependencies doesn't build due to a missing dependency. We therefore
-      # use the one that comes with nixpkgs (vs 0.2.5) for now
-      # datasets = hspkgs.callCabal2nix "datasets" "${dataHaskellCoreSrc}/datasets" {};
-      dh-core = hspkgs.callCabal2nix "dh-core" "${dataHaskellCoreSrc}/dh-core" {};
-      analyze = hspkgs.callCabal2nix "analyze" "${dataHaskellCoreSrc}/analyze" {};
-
       megaparsec = hspkgs.megaparsec_6_5_0;
 
-      # -- missing dependency
+      # missing dependency
       aeson = pkgs.haskell.lib.addBuildDepends hspkgs.aeson [ self.contravariant ];
-
-      # For Frames
-      # Latest version of singletons incompatible with GHC 8.4.4
-      vinyl_0_10_0 = hspkgs.vinyl_0_10_0_1;
-      singletons = dontCheck (hspkgs.callHackage "singletons" "2.4.1" {});
-      th-desugar = hspkgs.callHackage "th-desugar" "1.8" {};
-
-      # For funflow
-      funflow = pkgs.haskell.lib.dontCheck hspkgs.funflow;
-
-      # For TensorFlow, tests not passing
-      conduit-extra = dontCheck hspkgs.conduit-extra;
-
-      # For diagrams
-      diagrams-contrib = dontCheck hspkgs.diagrams-contrib;
     };
 in
 


### PR DESCRIPTION
This moves most of the overrides from the haskell overlay level to the
per project shell.nix level.

This will simplify the updating of Nixpkgs later.