### PR TITLE
Add an overlay file for JupyterWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,30 @@ $ cat result | docker load
 $ docker run -v $(pwd)/example:/data -p 8888:8888 jupyter-image:latest
 ```
 
+## Using as an overlay
+
+You can import JupyterWith as an overlay as follows:
+
+```
+let
+  path = import (builtins.fetchGit {
+    url = https://github.com/tweag/jupyterWith;
+    rev = "";
+  }) {};
+
+  overlays = [
+    # Only necessary for Haskell kernel
+    (import (path ++ /nix/haskell-overlay.nix))
+    # Necessary for Jupyter
+    (import (path ++ /nix/python-overlay.nix))
+    (import (path ++ /nix/overlay.nix))
+  ];
+
+  pkgs = import <nixpkgs> { inherit overlays; };
+in
+  pkgs.jupyterWith;
+```
+
 ## Contributing
 
 ### Kernels

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,5 @@
+_: pkgs:
+
+pkgs // {
+  jupyterWith = import ./. { inherit pkgs; };
+}


### PR DESCRIPTION
This should allow using JupyterWith as an overlay. The interface is not
ideal, but this allows to using different Nixpkgs snapshots (as long
APIs do not change).