### PR TITLE
Python kernel libraries are accessible from interpreter

### DIFF
--- a/kernels/ipython/default.nix
+++ b/kernels/ipython/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , name ? "nixpkgs"
 , packages ? (_:[])
+, writeScriptBin
 }:
 
 let
@@ -24,6 +25,10 @@ let
     logo64 = "logo-64x64.png";
   };
 
+  pythonBin = writeScriptBin "python-${name}" ''
+    ${kernelEnv.interpreter} "$@"
+  '';
+
   ipythonKernel = stdenv.mkDerivation {
     name = "ipython-${name}";
     src = ./python.png;
@@ -37,5 +42,8 @@ let
 in
   {
     spec = ipythonKernel;
-    runtimePackages = [];
+    runtimePackages = [
+      # Lets the user to use libraries from the Python command.
+      pythonBin
+    ];
   }


### PR DESCRIPTION
This lets the libraries that are accessible for the Python kernel be
accessible from the terminal. In order to launch the Python interpreter,
just run `python-$NAME`, where NAME is the name of the kernel given in
the kernel configuration.

The name given is different so that multiple Python kernels in the same
environment do not clash due to having the same name.