### PR TITLE
Haskell kernel libraries are accessible from interpreter

### DIFF
--- a/kernels/ihaskell/default.nix
+++ b/kernels/ihaskell/default.nix
@@ -9,6 +9,14 @@
 let
   ihaskellEnv = haskellPackages.ghcWithPackages (self: [ self.ihaskell ] ++ packages self);
 
+  ghciBin = writeScriptBin "ghci-${name}" ''
+    ${ihaskellEnv}/bin/ghci "$@"
+  '';
+
+  ghcBin = writeScriptBin "ghc-${name}" ''
+    ${ihaskellEnv}/bin/ghc "$@"
+  '';
+
   ihaskellSh = writeScriptBin "ihaskell" ''
     #! ${stdenv.shell}
     export GHC_PACKAGE_PATH="$(echo ${ihaskellEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
@@ -44,5 +52,10 @@ let
 in
   {
     spec = ihaskellKernel;
-    runtimePackages = [];
+    runtimePackages = [
+      # Give access to compiler and interpreter with the libraries accessible
+      # from the kernel.
+      ghcBin
+      ghciBin
+    ];
   }


### PR DESCRIPTION
This lets the libraries that are accessible for the Haskell kernel be
accessible from the terminal. In order to launch the Haskell interpreter,
just run ghci-$NAME, where NAME is the name of the kernel given in
the kernel configuration. The same works for ghc-$NAME.

The name given is different so that multiple Haskell kernels in the same
environment do not clash due to having the same name.