### PR TITLE
WIP: JupyterWith NixOS Service

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,13 +3,9 @@
 , pkgs ? import ./nix { inherit config overlays; }
 }:
 
-with (import ./lib/directory.nix { inherit pkgs; });
-with (import ./lib/docker.nix { inherit pkgs; });
-
 let
   # Kernel generators.
   kernels = pkgs.callPackage ./kernels {};
-  kernelsString = pkgs.lib.concatMapStringsSep ":" (k: "${k.spec}");
 
   # Python version setup.
   python3 = pkgs.python3Packages;
@@ -19,47 +15,23 @@ let
   defaultKernels = [ (kernels.iPythonWith {}) ];
   defaultExtraPackages = p: [];
 
+  # Import the main package components.
+  mkBase = pkgs.callPackage ./lib/base.nix {};
+
   # JupyterLab with the appropriate kernel and directory setup.
   jupyterlabWith = {
     directory ? defaultDirectory,
     kernels ? defaultKernels,
     extraPackages ? defaultExtraPackages
-    }:
+  }:
     let
-      # PYTHONPATH setup for JupyterLab
-      pythonPath = python3.makePythonPath [
-        python3.ipykernel
-        python3.jupyter_contrib_core
-        python3.jupyter_nbextensions_configurator
-        python3.tornado
-      ];
-
-      # JupyterLab executable wrapped with suitable environment variables.
-      jupyterlab = python3.toPythonModule (
-        python3.jupyterlab.overridePythonAttrs (oldAttrs: {
-          makeWrapperArgs = [
-            "--set JUPYTERLAB_DIR ${directory}"
-            "--set JUPYTER_PATH ${kernelsString kernels}"
-            "--set PYTHONPATH ${pythonPath}"
-          ];
-        })
-      );
-
-      # Shell with the appropriate JupyterLab, launching it at startup.
-      env = pkgs.mkShell {
-        name = "jupyterlab-shell";
-        buildInputs =
-          [ jupyterlab generateDirectory pkgs.nodejs ] ++
-          (map (k: k.runtimePackages) kernels) ++
-          (extraPackages pkgs);
-        shellHook = ''
-          export JUPYTER_PATH=${kernelsString kernels}
-          export JUPYTERLAB=${jupyterlab}
-        '';
-      };
+      base = mkBase { inherit directory kernels extraPackages; };
     in
-      jupyterlab.override (oldAttrs: {
-        passthru = oldAttrs.passthru or {} // { inherit env; };
-      });
+      base.jupyterlab;
 in
-  { inherit jupyterlabWith kernels mkDirectoryWith mkDockerImage; }
+
+{
+  inherit jupyterlabWith kernels;
+  mkDirectoryWith = pkgs.callPackage ./lib/directory.nix {};
+  mkDockerImage = pkgs.callPackage ./lib/docker.nix {};
+}

--- a/default.nix
+++ b/default.nix
@@ -28,10 +28,26 @@ let
       base = mkBase { inherit directory kernels extraPackages; };
     in
       base.jupyterlab;
+
+  # JupyterLab with the appropriate kernel and directory setup.
+  serviceWith = {
+    directory ? defaultDirectory,
+    kernels ? defaultKernels,
+    extraPackages ? defaultExtraPackages
+  }:
+    let
+      base = mkBase { inherit directory kernels extraPackages; };
+    in
+      import ./lib/service.nix {
+        inherit directory kernels extraPackages;
+        jupyterlab = base.jupyterlab;
+        environment = base.environment;
+        path = base.path;
+      };
 in
 
 {
-  inherit jupyterlabWith kernels;
+  inherit jupyterlabWith serviceWith kernels;
   mkDirectoryWith = pkgs.callPackage ./lib/directory.nix {};
   mkDockerImage = pkgs.callPackage ./lib/docker.nix {};
 }

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,9 @@
 , pkgs ? import ./nix { inherit config overlays; }
 }:
 
+with (import ./lib/directory.nix { inherit pkgs; });
+with (import ./lib/docker.nix { inherit pkgs; });
+
 let
   # Kernel generators.
   kernels = pkgs.callPackage ./kernels {};
@@ -47,7 +50,5 @@ let
 in
 
 {
-  inherit jupyterlabWith serviceWith kernels;
-  mkDirectoryWith = pkgs.callPackage ./lib/directory.nix {};
-  mkDockerImage = pkgs.callPackage ./lib/docker.nix {};
+  inherit jupyterlabWith serviceWith kernels mkDirectoryWith mkDockerImage;
 }

--- a/lib/base.nix
+++ b/lib/base.nix
@@ -1,0 +1,62 @@
+{ pkgs }:
+
+{ directory, kernels, extraPackages
+}:
+
+with (pkgs.callPackage ./directory.nix {});
+
+let
+
+  # Python version setup.
+  python3 = pkgs.python3Packages;
+
+  # Kernels string for environment variable.
+  kernelsString = pkgs.lib.concatMapStringsSep ":" (k: "${k.spec}");
+
+  # PYTHONPATH setup for JupyterLab.
+  pythonPath = python3.makePythonPath [
+    python3.ipykernel
+    python3.jupyter_contrib_core
+    python3.jupyter_nbextensions_configurator
+    python3.tornado
+  ];
+
+  # JupyterLab executable wrapped with suitable environment variables.
+  jupyterlab = python3.toPythonModule (
+    python3.jupyterlab.overridePythonAttrs (oldAttrs: {
+      makeWrapperArgs = [
+        "--set JUPYTERLAB_DIR ${directory}"
+        "--set JUPYTER_PATH ${kernelsString kernels}"
+        "--set PYTHONPATH ${pythonPath}"
+      ];
+    })
+  );
+
+  # Path variable for the environment.
+  path =
+    [ jupyterlab generateDirectory pkgs.nodejs ] ++
+    (map (k: k.runtimePackages) kernels) ++
+    (extraPackages pkgs);
+
+  # Environment variables for the Nix shell.
+  environment = {
+      JUPYTER_PATH = kernelsString kernels;
+      JUPYTERLAB = jupyterlab;
+  };
+
+  # Shell with the appropriate JupyterLab, launching it at startup.
+  env = pkgs.mkShell {
+    name = "jupyterlab-shell";
+    buildInputs = path;
+    shellHook = pkgs.lib.concatStringsSep "\n"
+      (pkgs.lib.mapAttrsToList (n: v: "export ${n}=${v}") environment);
+  };
+in
+
+{
+  jupyterlab = jupyterlab.override (oldAttrs: {
+    passthru = oldAttrs.passthru or {} // { inherit env; };
+  });
+  path = path;
+  environment = environment;
+}

--- a/lib/service.nix
+++ b/lib/service.nix
@@ -1,0 +1,133 @@
+{ directory, kernels, extraPackages
+, jupyterlab, environment, path
+}:
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jupyterWith;
+
+  notebookConfig = pkgs.writeText "jupyter_config.py" ''
+    ${cfg.notebookConfig}
+    c.NotebookApp.password = ${cfg.password}
+  '';
+
+in {
+
+  options.services.jupyterWith = {
+    enable = mkEnableOption "Jupyter development server";
+
+    ip = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = ''
+        IP address Jupyter will be listening on.
+      '';
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 8888;
+      description = ''
+        Port number Jupyter will be listening on.
+      '';
+    };
+
+    notebookDir = mkOption {
+      type = types.str;
+      default = "~/";
+      description = ''
+        Root directory for notebooks.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "jupyter";
+      description = ''
+        Name of the user used to run the jupyter service.
+        For security reason, jupyter should really not be run as root.
+        If not set (jupyter), the service will create a jupyter user with appropriate settings.
+      '';
+      example = "aborsu";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "jupyter";
+      description = ''
+        Name of the group used to run the jupyter service.
+        Use this if you want to create a group of users that are able to view the notebook directory's content.
+      '';
+      example = "users";
+    };
+
+    password = mkOption {
+      type = types.str;
+      description = ''
+        Password to use with notebook.
+        Can be generated using:
+          In [1]: from notebook.auth import passwd
+          In [2]: passwd('test')
+          Out[2]: 'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'
+          NOTE: you need to keep the single quote inside the nix string.
+        Or you can use a python oneliner:
+          "open('/path/secret_file', 'r', encoding='utf8').read().strip()"
+        It will be interpreted at the end of the notebookConfig.
+      '';
+      example = [
+        "'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'"
+        "open('/path/secret_file', 'r', encoding='utf8').read().strip()"
+      ];
+    };
+
+    notebookConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Raw jupyter config.
+      '';
+    };
+
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable  {
+      systemd.services.jupyterWith = {
+        description = "Jupyter development server";
+
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = environment;
+
+        serviceConfig = {
+          Restart = "always";
+          ExecStart = ''${jupyterlab}/bin/jupyter-lab \
+            --no-browser \
+            --ip=${cfg.ip} \
+            --port=${toString cfg.port} --port-retries 0 \
+            --notebook-dir=${cfg.notebookDir} \
+            --NotebookApp.config_file=${notebookConfig}
+          '';
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = "~";
+        };
+      };
+    })
+    (mkIf (cfg.enable && (cfg.group == "jupyter")) {
+      users.groups.jupyter = {};
+    })
+    (mkIf (cfg.enable && (cfg.user == "jupyter")) {
+      users.extraUsers.jupyter = {
+        extraGroups = [ cfg.group ];
+        home = "/var/lib/jupyter";
+        createHome = true;
+        useDefaultShell = true; # needed so that the user can start a terminal.
+      };
+    })
+  ];
+}


### PR DESCRIPTION
This works, but I am not completely satisfied with the organization yet. But I am pushing the PR so others can take a look. It's largely based (copied) from the one defined in Nixpkgs.

It can be used from `configuration.nix` as:

```
let jupyter = import /path/to/tweag/jupyterWith {};
in
{
  imports =
    [ ./hardware-configuration.nix
      (jupyter.serviceWith {})
    ];

   services = {
    jupyterWith = {
      enable = true;
      user = "guaraqe";
      group = "users";
      password = "password";
    };
}
```
