### PR TITLE
[feature] adds a "extraJupyterPath" arguments for local python module development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,28 @@ let
   };
 ```
 
-Here, the `p` argument corresponds to Nixpkgs checkout being used.
+Here, the `p` argument corresponds to Nixpkgs checkout being used. Note that
+this can easily be made to use packages from outside `jupyterWith`'s scope, by
+providing a function that ignores its argument:
+
+```nix
+  extraPackages = _ : [ pkgs.pandoc ];
+```
+
+You may also bring all inputs from a package in scope using the
+"extraInputsFrom" argument:
+
+``` nix
+let
+  jupyter = import (builtins.fetchGit {
+    url = https://github.com/tweag/jupyterWith;
+    rev = "";
+  }) {};
+
+  jupyterEnvironment = jupyter.jupyterlabWith {
+    extraInputsFrom = p: [p.pythonPackages.numpy];
+  };
+```
 
 ## Using as an overlay
 
@@ -222,6 +243,24 @@ let
 in
   pkgs.jupyterWith;
 ```
+
+## Importing local python packages
+
+You may use the `extraJupyterPath` arguments to add local
+python packages in scope:
+
+```
+let
+  jupyter = import (builtins.fetchGit {
+    url = https://github.com/tweag/jupyterWith;
+    rev = "";
+  }) {};
+
+  jupyterEnvironment = jupyter.jupyterlabWith {
+    extraJupyterPath = "${builtins.toPath ./.}/local_module/";
+  };
+```
+
 
 ## Contributing
 

--- a/default.nix
+++ b/default.nix
@@ -18,12 +18,14 @@ let
   defaultDirectory = "${python3.jupyterlab}/share/jupyter/lab";
   defaultKernels = [ (kernels.iPythonWith {}) ];
   defaultExtraPackages = p: [];
+  defaultExtraInputsFrom = p: [];
 
   # JupyterLab with the appropriate kernel and directory setup.
   jupyterlabWith = {
     directory ? defaultDirectory,
     kernels ? defaultKernels,
     extraPackages ? defaultExtraPackages,
+    extraInputsFrom ? defaultExtraInputsFrom,
     extraJupyterPath ? ""
     }:
     let
@@ -49,6 +51,7 @@ let
       # Shell with the appropriate JupyterLab, launching it at startup.
       env = pkgs.mkShell {
         name = "jupyterlab-shell";
+        inputsFrom = extraInputsFrom pkgs;
         buildInputs =
           [ jupyterlab generateDirectory pkgs.nodejs ] ++
           (map (k: k.runtimePackages) kernels) ++

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,8 @@ let
   jupyterlabWith = {
     directory ? defaultDirectory,
     kernels ? defaultKernels,
-    extraPackages ? defaultExtraPackages
+    extraPackages ? defaultExtraPackages,
+    extraJupyterPath ? ""
     }:
     let
       # PYTHONPATH setup for JupyterLab
@@ -39,8 +40,8 @@ let
         python3.jupyterlab.overridePythonAttrs (oldAttrs: {
           makeWrapperArgs = [
             "--set JUPYTERLAB_DIR ${directory}"
-            "--set JUPYTER_PATH ${kernelsString kernels}"
-            "--set PYTHONPATH ${pythonPath}"
+            "--set JUPYTER_PATH ${extraJupyterPath}:${kernelsString kernels}"
+            "--set PYTHONPATH ${extraJupyterPath}:${pythonPath}"
           ];
         })
       );


### PR DESCRIPTION
```
  jupyterLabEnvironment = jupyter.jupyterlabWith {
    extraJupyterPath = "${builtins.toPath ./.}/local_module/";
    # ...
  };
```
Adds another way to do local python modules, as the provided example allows for nix-wrapped python modules only - which does not allow for developing the module while the notebook is running. Let me know what you think about it, if you want docs, etc. Thanks.