### PR TITLE
Make the extraJupyterPath parameter a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,11 @@ in
   pkgs.jupyterWith;
 ```
 
-## Importing local python packages
+## Adding extra packages to the Jupyter PATH
 
-You may use the `extraJupyterPath` arguments to add local
-python packages in scope:
+You may use the `extraJupyterPath` arguments to add extra packages to the scope
+of Jupyter itself (i.e. not the kernel). For example, a local package can be
+added to the path as follows:
 
 ```
 let
@@ -258,10 +259,9 @@ let
   }) {};
 
   jupyterEnvironment = jupyter.jupyterlabWith {
-    extraJupyterPath = "${builtins.toPath ./.}/local_module/";
+    extraJupyterPath = pkgs: "${builtins.toPath ./.}/local_module/";
   };
 ```
-
 
 ## Contributing
 

--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ let
     kernels ? defaultKernels,
     extraPackages ? defaultExtraPackages,
     extraInputsFrom ? defaultExtraInputsFrom,
-    extraJupyterPath ? ""
+    extraJupyterPath ? _: ""
     }:
     let
       # PYTHONPATH setup for JupyterLab
@@ -42,8 +42,8 @@ let
         python3.jupyterlab.overridePythonAttrs (oldAttrs: {
           makeWrapperArgs = [
             "--set JUPYTERLAB_DIR ${directory}"
-            "--set JUPYTER_PATH ${extraJupyterPath}:${kernelsString kernels}"
-            "--set PYTHONPATH ${extraJupyterPath}:${pythonPath}"
+            "--set JUPYTER_PATH ${extraJupyterPath pkgs}:${kernelsString kernels}"
+            "--set PYTHONPATH ${extraJupyterPath pkgs}:${pythonPath}"
           ];
         })
       );


### PR DESCRIPTION
This should allow the solution in #86 to be written as:

```nix
let
  jupyter = import (builtins.fetchGit {
    url = https://github.com/tweag/jupyterWith;
    rev = "8a81a4aeffa339b80f23b88ca4de69423712c24a";
  }) {};

  iPython = jupyter.kernels.iPythonWith {
    name = "notebook";
    packages = p: with p; [
      numpy
      matplotlib
    ];
  };

  jupyterEnvironment =
    jupyter.jupyterlabWith {
      kernels = [ iPython ];
      directory = ./jupyterlab;
      extraPackages = p: [p.python3Packages.jupytext];
      extraJupyterPath = p: "${p.python3Packages.jupytext}/lib/python3.7/site-packages";
    };
in
  jupyterEnvironment.env
```

Take a look @mdtisdall.