### PR TITLE
Is it necessary to set python's argument of ignore collisions  to true by default?

### DIFF
--- a/kernels/ipython/README.md
+++ b/kernels/ipython/README.md
@@ -12,6 +12,8 @@ The IPython kernel can be used as follows:
     # Optional definition of `python3` to be used.
     # Useful for overlaying packages.
     python3 = pkgs.python3Packages;
+    # Optional value to true that ignore file collisions inside the packages environment
+    ignoreCollisions = false;
   };
 }
 ```

--- a/kernels/ipython/default.nix
+++ b/kernels/ipython/default.nix
@@ -6,11 +6,11 @@
 }:
 
 let
-  kernelEnv = python3.withPackages (p:
+  kernelEnv = (python3.withPackages (p:
     packages p ++ (with p; [
       ipykernel
     ])
-  );
+  )).override (args: { ignoreCollisions = true;});
 
   kernelFile = {
     display_name = "Python3 - ${name}";

--- a/kernels/ipython/default.nix
+++ b/kernels/ipython/default.nix
@@ -3,6 +3,7 @@
 , name ? "nixpkgs"
 , packages ? (_:[])
 , writeScriptBin
+, ignoreCollisions ? false
 }:
 
 let
@@ -10,7 +11,7 @@ let
     packages p ++ (with p; [
       ipykernel
     ])
-  )).override (args: { ignoreCollisions = true;});
+  )).override (args: { inherit ignoreCollisions;});
 
   kernelFile = {
     display_name = "Python3 - ${name}";


### PR DESCRIPTION
In my opinion and python experience.  this argument should be here.
What do you think?