### PR TITLE
Large warning for impure generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,13 @@ in
   jupyterEnvironment.env
 ```
 
-Another option is to use the impure `mkDirectoryWith` Nix function that comes
-with this repo:
+#### Impure generator
+
+WARNING: This is not guaranteed to work every time. Read this section
+thoroughly before trying.
+
+Another option, which is useful for simple tests, is to use the impure
+`mkDirectoryWith` Nix function that comes with this repo:
 
 ``` nix
 {


### PR DESCRIPTION
This generator is the cause of most issues registered in JupyterWith,
and is merely a convenience, with any more sofisticated use-case needing
a manually generated folder.

Therefore, I think it is not worth its weight, and it is better to
remove it.

@MMesch Just checking if you think this is a good idea too.