### PR TITLE
add temp CI job to test syspolicy impact

### DIFF
--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -16,3 +16,20 @@ jobs:
         name: jupyterwith
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-build tests -A build
+  macos_perf_test:
+    runs-on: macOS-latest
+    steps:
+    - name: Disable syspolicy assessments
+      run: |
+        spctl --status
+        sudo spctl --master-disable
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - uses: cachix/cachix-action@v6
+      with:
+        name: jupyterwith
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix-build tests -A build
+      


### PR DESCRIPTION
Starting in Catalina, macOS runs a syspolicyd "assessment" that hits the network for each binary/script executable. It does cache these results, but Nix tends to introduce many "new" executables per build. (You can read more about this at https://github.com/NixOS/nix/issues/3789).

This PR adds a temporary, redundant macOS job with these assessments disabled. I'm hoping you can adopt it for a few weeks to help me collect more data on how this affects real projects.