### PR TITLE
Build ihaskell_labextension from Github, not NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ disabled:
 
 For this to work, your user must be in the `nix.trustedUsers` list in `configuration.nix`.
 
+The
+[JupyterLab docs say that the `extensions` list elements can be](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#installing-extensions)
+ “the name of a valid JupyterLab
+extension npm package on npm,” or “can be a local directory containing
+the extension, a gzipped tarball, or a URL to a gzipped tarball.”
+
+For a “local directory containing the extension” use the impure `mkBuildExtension` function, for example:
+
+```nix
+        extensions = [
+          jupyter.mkBuildExtension "${ihaskellSrc}/ihaskell_labextension"
+        ];
+```
+
 ### Changes to the default package sets
 
 The kernel environments rely on the default package sets that are provided by

--- a/default.nix
+++ b/default.nix
@@ -69,6 +69,7 @@ in
   { inherit
       jupyterlabWith
       kernels
+      mkBuildExtension
       mkDirectoryWith
       mkDirectoryFromLockFile
       mkDockerImage;

--- a/example/Haskell/Funflow/shell.nix
+++ b/example/Haskell/Funflow/shell.nix
@@ -13,12 +13,14 @@ let
       ];
     };
 
+  ihaskell_labextension = import ../ihaskell_labextension.nix { inherit jupyter pkgs; };
+
   jupyterlabWithKernels =
     jupyter.jupyterlabWith {
       kernels = [ ihaskellWithPackages ];
       directory = jupyter.mkDirectoryWith {
         extensions = [
-          "jupyterlab-ihaskell"
+          ihaskell_labextension
         ];
       };
     };

--- a/example/Haskell/diagrams/shell.nix
+++ b/example/Haskell/diagrams/shell.nix
@@ -3,6 +3,8 @@ let
   jupyter = import jupyterLibPath {
     overlays = [ (import ./overlay.nix) ];
   };
+  nixpkgsPath = jupyterLibPath + "/nix";
+  pkgs = import nixpkgsPath {};
 
   ihaskellWithPackages = jupyter.kernels.iHaskellWith {
       name = "Frames";
@@ -12,12 +14,14 @@ let
       ];
     };
 
+  ihaskell_labextension = import ../ihaskell_labextension.nix { inherit jupyter pkgs; };
+
   jupyterlabWithKernels =
     jupyter.jupyterlabWith {
       kernels = [ ihaskellWithPackages ];
       directory = jupyter.mkDirectoryWith {
         extensions = [
-          "jupyterlab-ihaskell"
+        ihaskell_labextension
         ];
       };
     };

--- a/example/Haskell/ihaskell_labextension.nix
+++ b/example/Haskell/ihaskell_labextension.nix
@@ -1,0 +1,14 @@
+{jupyter,pkgs}:
+let
+  ihaskellSrc = pkgs.fetchFromGitHub {
+    owner = "gibiansky";
+    repo = "IHaskell";
+    rev = "d7dc460a421abaa41e04fe150e264bc2bab5cbad";
+    # This rev does not need to be the same as the IHaskell rev
+    # in ../../nix/haskell-overlay.nix
+    # The ihaskell kernel and the ihaskell_labextension come from the
+    # same repository but are independent.
+    sha256 = "157mqfprjbjal5mvrqwpgnfvc93fn1pqwwkhfpcs7jm5c34bkv3q";
+  };
+in
+  jupyter.mkBuildExtension "${ihaskellSrc}/ihaskell_labextension"


### PR DESCRIPTION
Add a `mkBuildExtension` function which creates a JupyterLab extension derivation from an extension source directory. This allows us to build __ihaskell_labextension__ from the Github repo instead of from NPM.

This Haskell examples *Funflow* and *diagrams* now produce a JupyterLab 2 with a working __ihaskell_labextension__. (All the other Haskell examples are currently not buildable at all?)

What do you think about this @guaraqe  ? Something like this would resolve #111 and also https://github.com/gibiansky/IHaskell/issues/1159 .
