### PR TITLE
Don't duplicate jupyterlab package in jupyterlabWith

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let
   python3 = pkgs.python3Packages;
 
   # Default configuration.
-  defaultDirectory = "${python3.jupyterlab}/share/jupyter/lab";
+  defaultDirectory = "$out/share/jupyter/lab";
   defaultKernels = [ (kernels.iPythonWith {}) ];
   defaultExtraPackages = p: [];
   defaultExtraInputsFrom = p: [];


### PR DESCRIPTION
`jupyterlabWith` is defined as a modified `python3.jupyterlab`, but it
also retains a reference to original by capturing it with
`defaultDirectory`. Since a modified version will have the same
directory, we can use `$out/share/jupyter/lab` instead.