### PR TITLE
 lib.mkDirectory: replace python3.7 to sitePackages

### DIFF
--- a/lib/directory.nix
+++ b/lib/directory.nix
@@ -18,7 +18,7 @@ in
         # consider that it comes from a folder without read access only as in
         # Nix
         mkdir -p "$DIRECTORY"/staging
-        cp ${jupyter}/lib/python3.7/site-packages/jupyterlab/staging/yarn.lock "$DIRECTORY"/staging
+        cp ${jupyter}/${pkgs.python3.sitePackages}/jupyterlab/staging/yarn.lock "$DIRECTORY"/staging
         chmod +w "$DIRECTORY"/staging/yarn.lock
 
         for EXT in "$@"; do echo "- $EXT"; done
@@ -36,7 +36,7 @@ in
         WORKDIR="lockfiles"
 
         mkdir -p "$DIRECTORY"/staging
-        cp ${jupyter}/lib/python3.7/site-packages/jupyterlab/staging/yarn.lock "$DIRECTORY"/staging
+        cp ${jupyter}/${pkgs.python3.sitePackages}/jupyterlab/staging/yarn.lock "$DIRECTORY"/staging
         chmod +w "$DIRECTORY"/staging/yarn.lock
 
         echo "Generating lockfiles for extensions:"
@@ -64,14 +64,14 @@ in
 
       npm install
       npm run build
-      '';
+    '';
     installPhase = ''
       mkdir -p $out/
       cp -r * $out/
-      '';
+    '';
   };
 
-  mkDirectoryFromLockFile = { yarnlock, packagefile, extensions ? [], sha256 }:
+  mkDirectoryFromLockFile = { yarnlock, packagefile, extensions ? [ ], sha256 }:
     let
       # Should this exist?
       copyExtension = { name, version }: ''
@@ -103,7 +103,7 @@ in
         # Copy the default JupyterLab folder to the build location and give
         # write permissions to it.
         mkdir -p $FOLDER
-        cp -R ${jupyter}/lib/python3.7/site-packages/jupyterlab/* $FOLDER
+        cp -R ${jupyter}/${pkgs.python3.sitePackages}/jupyterlab/* $FOLDER
         chmod -R +rw $FOLDER
 
         # Overwrite yarn.lock and package.json with the ones that we want. Make
@@ -154,7 +154,7 @@ in
         export HOME=$TMP
 
         mkdir -p appdir/staging
-        cp ${jupyter}/lib/python3.7/site-packages/jupyterlab/staging/yarn.lock appdir/staging
+        cp ${jupyter}/${pkgs.python3.sitePackages}/jupyterlab/staging/yarn.lock appdir/staging
         chmod +w appdir/staging/yarn.lock
 
         jupyter labextension install ${extStr} --app-dir=appdir --debug


### PR DESCRIPTION
This PR related my comment at https://github.com/tweag/jupyterWith/issues/124#issuecomment-694153591

- test with python38(recent nixpkgs)
```
wrapping `/nix/store/s1j7fk9sm91q4jzdv1747yrfqla31v51-python3.8-jupyterlab-2.2.4/bin/jupyter-lab'...
Rewriting #!/nix/store/685kq8pyhrvajah1hdsfn4q7gm3j4yd4-python3-3.8.5/bin/python3.8 to #!/nix/store/685kq8pyhrvajah1hdsfn4q7gm3j4yd4-python3-3.8.5
wrapping `/nix/store/s1j7fk9sm91q4jzdv1747yrfqla31v51-python3.8-jupyterlab-2.2.4/bin/jupyter-labextension'...
Rewriting #!/nix/store/685kq8pyhrvajah1hdsfn4q7gm3j4yd4-python3-3.8.5/bin/python3.8 to #!/nix/store/685kq8pyhrvajah1hdsfn4q7gm3j4yd4-python3-3.8.5
wrapping `/nix/store/s1j7fk9sm91q4jzdv1747yrfqla31v51-python3.8-jupyterlab-2.2.4/bin/jupyter-labhub'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
```
- test with python37 (current nixpkgs)
```
on3-3.7.7
wrapping `/nix/store/wfxfbym3ykw48a460gzcpgn1d5yx3h18-python3.7-jupyterlab-2.1.2/bin/jlpm'...
Rewriting #!/nix/store/nnfpapxzrhib9gxpj26f0i5h0ww9rfwc-python3-3.7.7/bin/python3.7 to #!/nix/store/nnfpapxzrhib9gxpj26f0i5h0ww9rfwc-python3-3.7.7
wrapping `/nix/store/wfxfbym3ykw48a460gzcpgn1d5yx3h18-python3.7-jupyterlab-2.1.2/bin/jupyter-lab'...
Rewriting #!/nix/store/nnfpapxzrhib9gxpj26f0i5h0ww9rfwc-python3-3.7.7/bin/python3.7 to #!/nix/store/nnfpapxzrhib9gxpj26f0i5h0ww9rfwc-python3-3.7.7
wrapping `/nix/store/wfxfbym3ykw48a460gzcpgn1d5yx3h18-python3.7-jupyterlab-2.1.2/bin/jupyter-labextension'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
```