### PR TITLE
Add option for custom ihaskell path

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: jupyterwith
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build tests -A build
+    - run: nix-build tests -A build -A kernel-tests

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: jupyterwith
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build tests -A build -A kernel-tests
+    - run: nix-build tests -A build -A kernel-tests.core

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: jupyterwith
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build tests -A build
+    - run: nix-build tests -A build -A kernel-tests

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: jupyterwith
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build tests -A build -A kernel-tests
+    - run: nix-build tests -A build -A kernel-tests.core

--- a/kernels/ihaskell/default.nix
+++ b/kernels/ihaskell/default.nix
@@ -14,7 +14,7 @@ let
   # ghc as the one used by `haskellPackages`.
   ihaskell = if customIHaskell == null then haskellPackages.ihaskell else customIHaskell;
 
-  ghcEnv = haskellPackages.ghcWithPackages (self: packages self);
+  ghcEnv = haskellPackages.ghcWithPackages (self: [ihaskell] ++ packages self);
 
   ghciBin = writeScriptBin "ghci-${name}" ''
     ${ghcEnv}/bin/ghci "$@"

--- a/kernels/ihaskell/default.nix
+++ b/kernels/ihaskell/default.nix
@@ -1,27 +1,34 @@
 { writeScriptBin
 , haskellPackages
 , stdenv
+, customIHaskell ? null
 , extraIHaskellFlags ? ""
 , name ? "nixpkgs"
 , packages ? (_:[])
 }:
 
 let
-  ihaskellEnv = haskellPackages.ghcWithPackages (self: [ self.ihaskell ] ++ packages self);
+  # By default we use the ihaskell included in the `haskellPackages` set, but you can 
+  # also specify one explicitely in case the ihaskell you want to use resides somewhere
+  # else. Note that you will likely need an ihaskell which was built using the same
+  # ghc as the one used by `haskellPackages`.
+  ihaskell = if customIHaskell == null then haskellPackages.ihaskell else customIHaskell;
+
+  ghcEnv = haskellPackages.ghcWithPackages (self: packages self);
 
   ghciBin = writeScriptBin "ghci-${name}" ''
-    ${ihaskellEnv}/bin/ghci "$@"
+    ${ghcEnv}/bin/ghci "$@"
   '';
 
   ghcBin = writeScriptBin "ghc-${name}" ''
-    ${ihaskellEnv}/bin/ghc "$@"
+    ${ghcEnv}/bin/ghc "$@"
   '';
 
   ihaskellSh = writeScriptBin "ihaskell" ''
     #! ${stdenv.shell}
-    export GHC_PACKAGE_PATH="$(echo ${ihaskellEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
-    export PATH="${stdenv.lib.makeBinPath ([ ihaskellEnv ])}:$PATH"
-    ${ihaskellEnv}/bin/ihaskell ${extraIHaskellFlags} -l $(${ihaskellEnv}/bin/ghc --print-libdir) "$@"'';
+    export GHC_PACKAGE_PATH="$(echo ${ghcEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
+    export PATH="${stdenv.lib.makeBinPath ([ ghcEnv ])}:$PATH"
+    ${ihaskell}/bin/ihaskell ${extraIHaskellFlags} -l $(${ghcEnv}/bin/ghc --print-libdir) "$@"'';
 
   kernelFile = {
     display_name = "Haskell - " + name;
@@ -42,7 +49,7 @@ let
     name = "ihaskell-kernel";
     phases = "installPhase";
     src = ./haskell.svg;
-    buildInputs = [ ihaskellEnv ];
+    buildInputs = [ ghcEnv ];
     installPhase = ''
       mkdir -p $out/kernels/ihaskell_${name}
       cp $src $out/kernels/ihaskell_${name}/logo-64x64.svg

--- a/tests/custom-ihaskell.nix
+++ b/tests/custom-ihaskell.nix
@@ -1,0 +1,24 @@
+# A custom IHaskell and haskellPackages built using a package set from haskell.nix instead of nixpkgs
+with (import ../. {});
+let
+  haskellNixSrc = (import (builtins.fetchGit {
+    url = https://github.com/input-output-hk/haskell.nix;
+    rev = "240403fbae3d28ba26e965bf22feabf89156916c";
+  }) {});
+  # Using the nixpkgs from jupyterWith + the overlays, etc. from haskell.nix
+  pkgs = import ../nix (with haskellNixSrc.nixpkgsArgs; {inherit config overlays;});
+  snapshot = pkgs.lib.getAttr "lts-16.9" pkgs.haskell-nix.snapshots;
+
+  # ihaskell coming from haskell.nix needs to include both the exe and library components
+  # in order to work properly with jupyterWith.
+  customIHaskell = pkgs.symlinkJoin {
+      name="ihaskell-hnix"; 
+      paths=[
+          snapshot.ihaskell.components.exes.ihaskell
+          snapshot.ihaskell.components.library
+        ];
+    };
+in {
+  inherit customIHaskell;
+  haskellPackages = snapshot;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -94,8 +94,14 @@ let
 
   kernel-tests = {
     # Note: joining these to avoid creating so many "result" directories in the working directory
-    core = pkgs.symlinkJoin {name="test-kernel-paths-core"; paths=(builtins.map test-kernel-path includedKernels);};
-    customIHaskell = pkgs.symlinkJoin {name="test-kernel-paths-ihaskell"; paths=(builtins.map test-kernel-path customIHaskellKernels);};
+    core = pkgs.symlinkJoin {
+      name="test-kernel-paths-core";
+      paths=(builtins.map test-kernel-path includedKernels);
+    };
+    customIHaskell = pkgs.symlinkJoin {
+      name="test-kernel-paths-ihaskell";
+      paths=(builtins.map test-kernel-path customIHaskellKernels);
+    };
   };
-  
+
 in { inherit build build-custom-ihaskell docker shell kernel-tests; }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,71 +1,101 @@
 with (import ../. {});
 let
+  pkgs = import ../nix {};
+  custom-ihaskell = import ./custom-ihaskell.nix;
+  test-kernel-path = pkgs.callPackage ./test-kernel-path.nix {};
+
+  includedKernels = with kernels; [
+      ( ansibleKernel {
+          name = "test";
+      })
+
+      ( cKernelWith {
+          name = "test";
+      })
+
+      ( gophernotes {
+          name = "test";
+      })
+
+      ( iHaskellWith {
+          name = "test";
+      })
+
+      # Doesn't build without a nmp install due to zeromq. Needs sandbox off.
+      #( iJavascript {
+      #   name = "test";
+      #})
+
+      ( iPythonWith {
+          name = "test";
+      })
+
+      ( iNixKernel {
+          name = "test";
+      })
+
+      # Fails on MacOS.
+      #( iRubyWith {
+      #    name = "test";
+      #})
+
+      # Juniper has been removed from rPackages for some reason.
+      #( juniperWith {
+      #    name = "test";
+      #})
+
+      # Fails on MacOS.
+      #( iRWith {
+      #    name = "test";
+      #})
+
+      # This is hard to make work. We will work on it later.
+      #( xeusCling {
+      #    name = "test";
+      #})
+
+      ( rustWith {
+          name = "test";
+      })
+    ];
+
+  customIHaskellKernels = with kernels; [
+     # One kernel which uses a custom ihaskell + the nixpkgs haskell package set
+    ( iHaskellWith {
+      name = "test";
+      customIHaskell = custom-ihaskell.customIHaskell;
+    })
+    # And another which uses a custom ihaskell + the haskell.nix haskell package set
+    ( iHaskellWith {
+      name = "test";
+      customIHaskell = custom-ihaskell.customIHaskell;
+      haskellPackages = custom-ihaskell.haskellPackages;
+    })
+  ];
+
   jupyterlab =
     jupyterlabWith {
-      kernels = with kernels; [
+      kernels = includedKernels;
+    };
 
-        ( ansibleKernel {
-            name = "test";
-        })
-
-        ( cKernelWith {
-            name = "test";
-        })
-
-        ( gophernotes {
-            name = "test";
-        })
-
-        ( iHaskellWith {
-            name = "test";
-        })
-
-        # Doesn't build without a nmp install due to zeromq. Needs sandbox off.
-        #( iJavascript {
-        #   name = "test";
-        #})
-
-        ( iPythonWith {
-            name = "test";
-        })
-
-        ( iNixKernel {
-            name = "test";
-        })
-
-        # Fails on MacOS.
-        #( iRubyWith {
-        #    name = "test";
-        #})
-
-        # Juniper has been removed from rPackages for some reason.
-        #( juniperWith {
-        #    name = "test";
-        #})
-
-        # Fails on MacOS.
-        #( iRWith {
-        #    name = "test";
-        #})
-
-        # This is hard to make work. We will work on it later.
-        #( xeusCling {
-        #    name = "test";
-        #})
-
-        ( rustWith {
-            name = "test";
-        })
-      ];
+  jupyterlabCustomIHaskell =
+    jupyterlabWith {
+      kernels = customIHaskellKernels;
     };
 
   # Made for uploading to cachix:
   # nix-build -A build | cachix push jupyterwith
   build = jupyterlab;
+  build-custom-ihaskell = jupyterlabCustomIHaskell;
 
   shell = jupyterlab.env;
 
   docker = mkDockerImage { inherit jupyterlab; };
 
-in
-  { inherit build docker shell; }
+  kernel-tests = {
+    # Note: joining these to avoid creating so many "result" directories in the working directory
+    core = pkgs.symlinkJoin {name="test-kernel-paths-core"; paths=(builtins.map test-kernel-path includedKernels);};
+    customIHaskell = pkgs.symlinkJoin {name="test-kernel-paths-ihaskell"; paths=(builtins.map test-kernel-path customIHaskellKernels);};
+  };
+  
+in { inherit build build-custom-ihaskell docker shell kernel-tests; }

--- a/tests/test-kernel-path.nix
+++ b/tests/test-kernel-path.nix
@@ -1,0 +1,26 @@
+# This module defines a function for testing whether a kernel's executable
+# is a real path. This helps catch issues where a kernel module can write a
+# non-existent path which will build without any errors but fail at runtime.
+{ runCommand, jq }:
+kernel:
+runCommand "test-kernel-path" { buildInputs = [ jq ]; } ''
+  set -e
+
+  # Check that the kernel's command exists and is executable. If it is not, throw an error.
+  for spec in ${kernel.spec}/kernels/*/kernel.json; do
+      echo "Testing kernel json spec: $spec"
+
+      kernel_exe=$(jq --raw-output ".argv[0]" "$spec")
+      if [[ -z $kernel_exe || $kernel_exe == "null" ]]; then 
+          echo "No kernel exe found in the kernel json file."
+          exit 1
+      fi 
+
+      echo "Looking for kernel executable: $kernel_exe"
+      if [[ ! -x "$kernel_exe" ]]; then
+          echo "The executable defined in kernel file $spec is invalid" 
+          exit 1
+      fi
+  done
+  mkdir $out
+''


### PR DESCRIPTION
When attempting to integrate a haskell.nix project with IHaskell and jupyterWith, I ran into an issue where the `ghcWithPackages` function in the [haskell.nix](https://github.com/input-output-hk/haskell.nix) haskell package set doesn't add executables to the ghc environment it creates. This causes jupyterWith to generate an invalid ihaskell kernel file since the path it contains points to a non-existent ihaskell executable.

This PR addresses this issue by adding an extra input to the ihaskell kernel derivation which allows users to optionally specify a custom ihaskell derivation instead of using the one that resides in the input haskellPackages set. This allows users of haskell.nix to use the packages they build using that with jupyterWith + ihaskell. The default ihaskell is still the same as in the current implementation.