### PR TITLE
default.nix: export nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -73,4 +73,5 @@ in
       mkDirectoryWith
       mkDirectoryFromLockFile
       mkDockerImage;
+    nixpkgs = pkgs;
   }


### PR DESCRIPTION
Use case: using nixpkgs from jupyterWith to add custom packages (e.g.
manually or with mach-nix) for use in the final environment.