### PR TITLE
Fix ruby kernel

### DIFF
--- a/kernels/iruby/gemdir/Gemfile
+++ b/kernels/iruby/gemdir/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
-gem 'sensu'
 gem 'iruby'
-gem 'cztop'
-gem 'ffi-rzmq'
-gem 'rbczmq'
+gem 'rake'

--- a/kernels/iruby/gemdir/Gemfile.lock
+++ b/kernels/iruby/gemdir/Gemfile.lock
@@ -1,127 +1,37 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    amq-protocol (2.0.1)
-    amqp (1.6.0)
-      amq-protocol (>= 2.0.1)
-      eventmachine
-    bond (0.5.1)
-    childprocess (0.5.8)
-      ffi (~> 1.0, >= 1.0.11)
-    cookiejar (0.3.3)
-    czmq-ffi-gen (0.15.0)
-      ffi (~> 1.9.10)
-    cztop (0.13.1)
-      czmq-ffi-gen (~> 0.15.0)
     data_uri (0.1.0)
-    em-http-request (1.1.5)
-      addressable (>= 2.3.4)
-      cookiejar (!= 0.3.1)
-      em-socksify (>= 0.3)
-      eventmachine (>= 1.0.3)
-      http_parser.rb (>= 0.6.0)
-    em-http-server (0.1.8)
-      eventmachine
-    em-socksify (0.3.2)
-      eventmachine (>= 1.0.0.beta.4)
-    em-worker (0.0.2)
-      eventmachine
-    eventmachine (1.2.7)
-    ffi (1.9.21)
+    ffi (1.15.5)
     ffi-rzmq (2.0.7)
       ffi-rzmq-core (>= 1.0.7)
     ffi-rzmq-core (1.0.7)
       ffi
-    http_parser.rb (0.6.0)
-    iruby (0.3)
-      bond (~> 0.5)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
+    iruby (0.7.4)
       data_uri (~> 0.1)
-      mimemagic (~> 0.3)
+      ffi-rzmq
+      irb
+      mime-types (>= 3.3.1)
       multi_json (~> 1.11)
-    mimemagic (0.4.3)
-      nokogiri (~> 1)
-      rake
-    mini_portile2 (2.6.1)
-    multi_json (1.13.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
-    oj (2.18.1)
-    parse-cron (0.1.4)
-    public_suffix (4.0.6)
-    racc (1.5.2)
+      native-package-installer
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    multi_json (1.15.0)
+    native-package-installer (1.1.3)
     rake (13.0.6)
-    rbczmq (1.7.9)
-    sensu (1.6.2)
-      em-http-request (= 1.1.5)
-      em-http-server (= 0.1.8)
-      eventmachine (= 1.2.7)
-      parse-cron (= 0.1.4)
-      sensu-extension (= 1.5.2)
-      sensu-extensions (= 1.10.0)
-      sensu-json (= 2.1.1)
-      sensu-logger (= 1.2.2)
-      sensu-redis (= 2.4.0)
-      sensu-settings (= 10.14.0)
-      sensu-spawn (= 2.5.0)
-      sensu-transport (= 8.2.0)
-    sensu-extension (1.5.2)
-      eventmachine
-    sensu-extensions (1.10.0)
-      sensu-extension
-      sensu-extensions-check-dependencies (= 1.1.0)
-      sensu-extensions-debug (= 1.0.0)
-      sensu-extensions-json (= 1.0.0)
-      sensu-extensions-occurrences (= 1.2.0)
-      sensu-extensions-only-check-output (= 1.0.0)
-      sensu-extensions-ruby-hash (= 1.0.0)
-      sensu-json (>= 1.1.0)
-      sensu-logger
-      sensu-settings
-    sensu-extensions-check-dependencies (1.1.0)
-      sensu-extension
-    sensu-extensions-debug (1.0.0)
-      sensu-extension
-    sensu-extensions-json (1.0.0)
-      sensu-extension
-    sensu-extensions-occurrences (1.2.0)
-      sensu-extension
-    sensu-extensions-only-check-output (1.0.0)
-      sensu-extension
-    sensu-extensions-ruby-hash (1.0.0)
-      sensu-extension
-    sensu-json (2.1.1)
-      oj (= 2.18.1)
-    sensu-logger (1.2.2)
-      eventmachine
-      sensu-json
-    sensu-redis (2.4.0)
-      eventmachine
-    sensu-settings (10.14.0)
-      parse-cron
-      sensu-json (>= 1.1.0)
-    sensu-spawn (2.5.0)
-      childprocess (= 0.5.8)
-      em-worker (= 0.0.2)
-      eventmachine
-      ffi (= 1.9.21)
-    sensu-transport (8.2.0)
-      amq-protocol (= 2.0.1)
-      amqp (= 1.6.0)
-      eventmachine
-      sensu-redis (>= 1.0.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
-  cztop
-  ffi-rzmq
   iruby
-  rbczmq
-  sensu
+  rake
 
 BUNDLED WITH
-   1.17.2
+   2.2.20

--- a/kernels/iruby/gemdir/gemset.nix
+++ b/kernels/iruby/gemdir/gemset.nix
@@ -1,89 +1,4 @@
 {
-  addressable = {
-    dependencies = ["public_suffix"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0bcm2hchn897xjhqj9zzsxf3n9xhddymj4lsclz508f4vw3av46l";
-      type = "gem";
-    };
-    version = "2.6.0";
-  };
-  amq-protocol = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1rpn9vgh7y037aqhhp04smihzr73vp5i5g6xlqlha10wy3q0wp7x";
-      type = "gem";
-    };
-    version = "2.0.1";
-  };
-  amqp = {
-    dependencies = ["amq-protocol" "eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0kbrqnpjgj9v0722p3n5rw589l4g26ry8mcghwc5yr20ggkpdaz9";
-      type = "gem";
-    };
-    version = "1.6.0";
-  };
-  bond = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1r19ifc4skyl2gxnifrxa5jvbbay9fb2in79ppgv02b6n4bhsw90";
-      type = "gem";
-    };
-    version = "0.5.1";
-  };
-  childprocess = {
-    dependencies = ["ffi"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1lv7axi1fhascm9njxh3lx1rbrnsm8wgvib0g7j26v4h1fcphqg0";
-      type = "gem";
-    };
-    version = "0.5.8";
-  };
-  cookiejar = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0q0kmbks9l3hl0wdq744hzy97ssq9dvlzywyqv9k9y1p3qc9va2a";
-      type = "gem";
-    };
-    version = "0.3.3";
-  };
-  czmq-ffi-gen = {
-    dependencies = ["ffi"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1ngsd1yxiayd50v402vwhmq7ma9ang6pcba5kqiwq7smpdvfmbmp";
-      type = "gem";
-    };
-    version = "0.15.0";
-  };
-  cztop = {
-    dependencies = ["czmq-ffi-gen"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "12xcz7g42dbp2ryhcwdm2ykj7bmwfhjhla296hy18g7a09zlfnz7";
-      type = "gem";
-    };
-    version = "0.13.1";
-  };
   data_uri = {
     groups = ["default"];
     platforms = [];
@@ -94,69 +9,15 @@
     };
     version = "0.1.0";
   };
-  em-http-request = {
-    dependencies = ["addressable" "cookiejar" "em-socksify" "eventmachine" "http_parser.rb"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "13rxmbi0fv91n4sg300v3i9iiwd0jxv0i6xd0sp81dx3jlx7kasx";
-      type = "gem";
-    };
-    version = "1.1.5";
-  };
-  em-http-server = {
-    dependencies = ["eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0y8l4gymy9dzjjchjav90ck6has2i2zdjihlhcyrg3jgq6kjzyq5";
-      type = "gem";
-    };
-    version = "0.1.8";
-  };
-  em-socksify = {
-    dependencies = ["eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0rk43ywaanfrd8180d98287xv2pxyl7llj291cwy87g1s735d5nk";
-      type = "gem";
-    };
-    version = "0.3.2";
-  };
-  em-worker = {
-    dependencies = ["eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0z4jx9z2q5hxvdvik4yp0ahwfk69qsmdnyp72ln22p3qlkq2z5wk";
-      type = "gem";
-    };
-    version = "0.0.2";
-  };
-  eventmachine = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0wh9aqb0skz80fhfn66lbpr4f86ya2z5rx6gm5xlfhd05bj1ch4r";
-      type = "gem";
-    };
-    version = "1.2.7";
-  };
   ffi = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0c2dl10pi6a30kcvx2s6p2v1wb4kbm48iv38kmz2ff600nirhpb8";
+      sha256 = "6f2ed2fa68047962d6072b964420cba91d82ce6fa8ee251950c17fca6af3c2a0";
       type = "gem";
     };
-    version = "1.9.21";
+    version = "1.15.5";
   };
   ffi-rzmq = {
     dependencies = ["ffi-rzmq-core"];
@@ -180,250 +41,98 @@
     };
     version = "1.0.7";
   };
-  "http_parser.rb" = {
+  io-console = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15nidriy0v5yqfjsgsra51wmknxci2n2grliz78sf9pga3n0l7gi";
+      sha256 = "7e2418376fd185ad66e7aee2c58c207e9be0f2197aa89bc4c89931995cee3365";
       type = "gem";
     };
-    version = "0.6.0";
+    version = "0.5.11";
+  };
+  irb = {
+    dependencies = ["reline"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "4a6698d9ab9de30ffd2def6fb17327f5d0fc089ace62337eff95396f379bf0a8";
+      type = "gem";
+    };
+    version = "1.4.1";
   };
   iruby = {
-    dependencies = ["bond" "data_uri" "mimemagic" "multi_json"];
+    dependencies = ["data_uri" "ffi-rzmq" "irb" "mime-types" "multi_json" "native-package-installer" "rake"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wdf2c0x8y6cya0n3y0p3p7b1sxkb2fdavdn2k58rf4rs37s7rzn";
+      sha256 = "cc219e2ac797c3fbf8c2b937ee7d26547723c8ae0e5ad65f2975aa3325b3a620";
       type = "gem";
     };
-    version = "0.3";
+    version = "0.7.4";
   };
-  mimemagic = {
+  mime-types = {
+    dependencies = ["mime-types-data"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04cp5sfbh1qx82yqxn0q75c7hlcx8y1dr5g3kyzwm4mx6wi2gifw";
+      sha256 = "6bcf8b0e656b6ae9977bdc1351ef211d0383252d2f759a59ef4bcf254542fc46";
       type = "gem";
     };
-    version = "0.3.3";
+    version = "3.4.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "d8c401ba9ea8b648b7145b90081789ec714e91fd625d82c5040079c5ea696f00";
+      type = "gem";
+    };
+    version = "3.2022.0105";
   };
   multi_json = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1rl0qy4inf1mp8mybfk56dfga0mvx97zwpmq5xmiwl5r770171nv";
+      sha256 = "1fd04138b6e4a90017e8d1b804c039031399866ff3fbabb7822aea367c78615d";
       type = "gem";
     };
-    version = "1.13.1";
+    version = "1.15.0";
   };
-  oj = {
+  native-package-installer = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "147whmq8h2n04chskl3v4a132xhz5i6kk6vhnz83jwng4vihin5f";
+      sha256 = "ba899df70489b748a3fe1b48afe6325d1cb8ca67fdff759266c275b911c797dd";
       type = "gem";
     };
-    version = "2.18.1";
+    version = "1.1.3";
   };
-  parse-cron = {
+  rake = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "02fj9i21brm88nb91ikxwxbwv9y7mb7jsz6yydh82rifwq7357hg";
+      sha256 = "5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097";
       type = "gem";
     };
-    version = "0.1.4";
+    version = "13.0.6";
   };
-  public_suffix = {
+  reline = {
+    dependencies = ["io-console"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
+      sha256 = "b101d93607bf7564657f082f68abfa19ae939d14a709eff89be048eae2d7f4c7";
       type = "gem";
     };
-    version = "3.0.3";
-  };
-  rbczmq = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1bqr44m2nb61smza6y5cahp09hk16lsn0z3wpq9g5zpr9nhp50fx";
-      type = "gem";
-    };
-    version = "1.7.9";
-  };
-  sensu = {
-    dependencies = ["em-http-request" "em-http-server" "eventmachine" "parse-cron" "sensu-extension" "sensu-extensions" "sensu-json" "sensu-logger" "sensu-redis" "sensu-settings" "sensu-spawn" "sensu-transport"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1rxv6yj63nkxlzmmqk6qpfpcvrbar9s4sd4kgfb5zsv9bw7236cr";
-      type = "gem";
-    };
-    version = "1.6.2";
-  };
-  sensu-extension = {
-    dependencies = ["eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0bpizp4n01rv72cryjjlrbfxxj3csish3mkxjzdy4inpi5j5h1dw";
-      type = "gem";
-    };
-    version = "1.5.2";
-  };
-  sensu-extensions = {
-    dependencies = ["sensu-extension" "sensu-extensions-check-dependencies" "sensu-extensions-debug" "sensu-extensions-json" "sensu-extensions-occurrences" "sensu-extensions-only-check-output" "sensu-extensions-ruby-hash" "sensu-json" "sensu-logger" "sensu-settings"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "04v221qjv8qy3jci40i66p63ig5vrrh0dpgmf1l8229x5m7bxrsg";
-      type = "gem";
-    };
-    version = "1.10.0";
-  };
-  sensu-extensions-check-dependencies = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1hc4kz7k983f6fk27ikg5drvxm4a85qf1k07hqssfyk3k75jyj1r";
-      type = "gem";
-    };
-    version = "1.1.0";
-  };
-  sensu-extensions-debug = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "11abdgn2kkkbvxq4692yg6a27qnxz4349gfiq7d35biy7vrw34lp";
-      type = "gem";
-    };
-    version = "1.0.0";
-  };
-  sensu-extensions-json = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1wnbn9sycdqdh9m0fhszaqkv0jijs3fkdbvcv8kdspx6irbv3m6g";
-      type = "gem";
-    };
-    version = "1.0.0";
-  };
-  sensu-extensions-occurrences = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0lx5wsbblfs0rvkxfg09bsz0g2mwmckrhga7idnarsnm8m565v1v";
-      type = "gem";
-    };
-    version = "1.2.0";
-  };
-  sensu-extensions-only-check-output = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0ds2i8wd4ji9ifig2zzr4jpxinvk5dm7j10pvaqy4snykxa3rqh3";
-      type = "gem";
-    };
-    version = "1.0.0";
-  };
-  sensu-extensions-ruby-hash = {
-    dependencies = ["sensu-extension"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1xyrj3gbmslbivcd5qcmyclgapn7qf7f5jwfvfpw53bxzib0h7s3";
-      type = "gem";
-    };
-    version = "1.0.0";
-  };
-  sensu-json = {
-    dependencies = ["oj"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "08zlxg5j3bhs72cc7wcllp026jbif0xiw6ib1cgawndlpsfl9fgx";
-      type = "gem";
-    };
-    version = "2.1.1";
-  };
-  sensu-logger = {
-    dependencies = ["eventmachine" "sensu-json"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0jpw4kz36ilaknrzb3rbkhpbgv93w2d668z2cv395dq30d4d3iwm";
-      type = "gem";
-    };
-    version = "1.2.2";
-  };
-  sensu-redis = {
-    dependencies = ["eventmachine"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0widfmmj1h9ca2kk14wy1sqmlkq40linp89a73s3ghngnzri0xyk";
-      type = "gem";
-    };
-    version = "2.4.0";
-  };
-  sensu-settings = {
-    dependencies = ["parse-cron" "sensu-json"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "152n4hazv2l4vbzrgd316rpj135jmz042fyh6k2yv2kw0x29pi0f";
-      type = "gem";
-    };
-    version = "10.14.0";
-  };
-  sensu-spawn = {
-    dependencies = ["childprocess" "em-worker" "eventmachine" "ffi"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "17yc8ivjpjbvig9r7yl6991d6ma0kcq75fbpz6i856ljvcr3lmd5";
-      type = "gem";
-    };
-    version = "2.5.0";
-  };
-  sensu-transport = {
-    dependencies = ["amq-protocol" "amqp" "eventmachine" "sensu-redis"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0x6vyfmg1jm1srf7xa5aka73by7qwcmry2rx8kq8phwa4g0v4mzr";
-      type = "gem";
-    };
-    version = "8.2.0";
+    version = "0.3.1";
   };
 }

--- a/kernels/iruby/gemdir/generate.sh
+++ b/kernels/iruby/gemdir/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell --pure -I nixpkgs=../../nix -i bash -p bundler -p bundix
+#! nix-shell --pure -I nixpkgs=../../../nix/nixpkgs.nix -i bash -p bundler -p bundix
 
 bundle lock
 bundix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,10 +37,9 @@ let
       name = "test";
     })
 
-    # Fails on MacOS.
-    #( iRubyWith {
-    #    name = "test";
-    #})
+    (iRubyWith {
+      name = "test";
+    })
 
     # Juniper has been removed from rPackages for some reason.
     #( juniperWith {


### PR DESCRIPTION
This fixes the ruby kernel by updating `iruby` to 0.7.4, and removing unnecessary gems.