### PR TITLE
Allow PATH customisation and add NodeJS to PATH

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,8 @@ let
         python3.jupyter_nbextensions_configurator
         python3.tornado
       ];
-      extraPath = pkgs.lib.makeBinPath (extraPackages pkgs);
+      # NodeJS is required for extensions
+      extraPath = pkgs.lib.makeBinPath ([ pkgs.nodejs ] ++ extraPackages pkgs);
 
       # JupyterLab executable wrapped with suitable environment variables.
       jupyterlab = python3.toPythonModule (

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ let
         python3.jupyter_nbextensions_configurator
         python3.tornado
       ];
+      extraPath = pkgs.lib.makeBinPath (extraPackages pkgs);
 
       # JupyterLab executable wrapped with suitable environment variables.
       jupyterlab = python3.toPythonModule (
@@ -44,6 +45,7 @@ let
             "--set JUPYTERLAB_DIR ${directory}"
             "--set JUPYTER_PATH ${extraJupyterPath pkgs}:${kernelsString kernels}"
             "--set PYTHONPATH ${extraJupyterPath pkgs}:${pythonPath}"
+            "--prefix PATH : ${extraPath}"
           ];
         })
       );


### PR DESCRIPTION
There are two changes:

1. Wrap jupyterlab so that `extraPackages` are added to its PATH, not only to the dev shell. I was looking for a way to do this (e.g. to add texlive so that I can export to PDF), found `extraPackages` and was really surprised that it did not do what I expected.
2. Add NodeJS to PATH (fixes #189).