### PR TITLE
fix pkgs.python3Packages to pkgs.python3.pkgs for flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
   kernelsString = pkgs.lib.concatMapStringsSep ":" (k: "${k.spec}");
 
   # Python version setup.
-  python3 = pkgs.python3Packages;
+  python3 = pkgs.python3.pkgs;
 
   # Default configuration.
   defaultDirectory = "$out/share/jupyter/lab";


### PR DESCRIPTION
 `pkgs.python3Packages` doesn't work with `flake.nix`