### PR TITLE
next-feature/fix-jupyter-paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,11 @@
 
           # create directories for storing jupyter configs
           jupyterDir = pkgs.runCommand "jupyter-dir" {} ''
+            # make jupyter config and data directories
             mkdir -p $out/config $out/data
+
+            # make jupyter lab user settings and workspaces directories
+            mkdir -p $out/config/lab/{user-settings,workspaces}
           '';
         in
           pkgs.runCommand "wrapper-${jupyterlab.name}"


### PR DESCRIPTION
JupyterLab expected certain directories, for user settings and workspaces, to exist under Jupyter's config directories. The needed directories were adding to the `jupyterDir` derivation so we can add config files in the future.