### PR TITLE
Move `python3` to overridable scope. Allow `poetry2nix` to override `nix/python-overlay.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { overlays ? []
 , config ? {}
 , pkgs ? import ./nix { inherit config overlays; }
+, python3 ? pkgs.python3
 }:
 
 with (import ./lib/directory.nix { inherit pkgs; });
@@ -10,9 +11,6 @@ let
   # Kernel generators.
   kernels = pkgs.callPackage ./kernels {};
   kernelsString = pkgs.lib.concatMapStringsSep ":" (k: "${k.spec}");
-
-  # Python version setup.
-  python3 = pkgs.python3.pkgs;
 
   # Default configuration.
   defaultDirectory = "$out/share/jupyter/lab";
@@ -30,18 +28,18 @@ let
     }:
     let
       # PYTHONPATH setup for JupyterLab
-      pythonPath = python3.makePythonPath [
-        python3.ipykernel
-        python3.jupyter_contrib_core
-        python3.jupyter_nbextensions_configurator
-        python3.tornado
+      pythonPath = python3.pkgs.makePythonPath [
+        python3.pkgs.ipykernel
+        python3.pkgs.jupyter_contrib_core
+        python3.pkgs.jupyter_nbextensions_configurator
+        python3.pkgs.tornado
       ];
       # NodeJS is required for extensions
       extraPath = pkgs.lib.makeBinPath ([ pkgs.nodejs ] ++ extraPackages pkgs);
 
       # JupyterLab executable wrapped with suitable environment variables.
-      jupyterlab = python3.toPythonModule (
-        python3.jupyterlab.overridePythonAttrs (oldAttrs: {
+      jupyterlab = python3.pkgs.toPythonModule (
+        python3.pkgs.jupyterlab.overridePythonAttrs (oldAttrs: {
           makeWrapperArgs = oldAttrs.makeWrapperArgs or [] ++ [
             "--set JUPYTERLAB_DIR ${directory}"
             "--set JUPYTER_PATH ${extraJupyterPath pkgs}:${kernelsString kernels}"

--- a/nix/python-overlay.nix
+++ b/nix/python-overlay.nix
@@ -100,4 +100,7 @@ in
         (old.packageOverrides or (_: _: {}))
         packageOverrides;
   });
+  poetry2nix = prev.poetry2nix.overrideScope' (p2nixfinal: p2nixprev: {
+    defaultPoetryOverrides = p2nixprev.defaultPoetryOverrides.extend packageOverrides;
+  });
 }


### PR DESCRIPTION
1. Allow users to override `python3` in `default.nix` so that one can either change the version of `python3` or override `python3` with custom python environment such as `poetry2nix` python environment.
2. When using `jupyterWith` with `poetry2nix`, duplicated packages error occur often a lot due to each of them making separate set of python packages. To overcome the problem, `poetry2nix` needs to be able to override `jupyterWith` overlay in its `defaultPoetryOverrides`.