### PR TITLE
Next feature/fix jupyter lab paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -212,9 +212,11 @@
               ln -s ${jupyterlab}/bin/$filename $out/bin/$filename
               wrapProgram $out/bin/$filename \
                 --set JUPYTERLAB_DIR ${jupyterlab}/share/jupyter/lab \
+                --set JUPYTERLAB_SETTINGS_DIR ".jupyter/lab/user-settings" \
+                --set JUPYTERLAB_WORKSPACES_DIR ".jupyter/lab/workspaces" \
                 --set JUPYTER_PATH ${kernelsString requestedKernels} \
                 --set JUPYTER_CONFIG_DIR "${jupyterDir}/config" \
-                --set JUPYTER_DATA_DIR "${jupyterDir}/data" \
+                --set JUPYTER_DATA_DIR ".jupyter/data" \
                 --set IPYTHONDIR "/path-not-set" \
                 --set JUPYTER_RUNTIME_DIR "/path-not-set"
             done


### PR DESCRIPTION
Closes #226.
JupyterLab user settings and workspaces directories have been updated with a temporary fix.
While debugging, it was discovered that the Jupyter data directory also needed to be moved to a writable location. It also has been given a temporary fix.