### PR TITLE
Set IPYTHONDIR to a temporary controlled location.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -217,7 +217,7 @@
                 --set JUPYTER_PATH ${kernelsString requestedKernels} \
                 --set JUPYTER_CONFIG_DIR "${jupyterDir}/config" \
                 --set JUPYTER_DATA_DIR ".jupyter/data" \
-                --set IPYTHONDIR "/path-not-set" \
+                --set IPYTHONDIR ".jupyter/.ipython" \
                 --set JUPYTER_RUNTIME_DIR "/path-not-set"
             done
           '';


### PR DESCRIPTION
Fixes #230. `IPYTHONDIR` should be set to a writable location similar to what was down for the jupyterlab user settings and workspaces directories in #229.