### PR TITLE
next-feature/update-templates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -345,7 +345,7 @@
         lib = {inherit mkJupyterEnvFromKernelPath;};
         packages = {inherit jupyterlab example_jupyterlab;};
         packages.default = packages.jupyterlab;
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           packages = [
             pkgs.alejandra
             poetry2nix.defaultPackage.${system}

--- a/flake.nix
+++ b/flake.nix
@@ -337,7 +337,7 @@
               );
           };
       in rec {
-        lib = {inherit mkKernel mkJupyterlabInstance;};
+        lib = {inherit readKernelsFromPath;};
         packages = {inherit jupyterlab example_jupyterlab;};
         packages.default = packages.jupyterlab;
         devShell = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -361,7 +361,7 @@
       }
     ))
     // {
-      defaultTemplate = {
+      templates.default = {
         path = ./template;
         description = "Boilerplate for your jupyter-nix project";
         welcomeText = builtins.readFile ./template/README.md;

--- a/flake.nix
+++ b/flake.nix
@@ -333,7 +333,7 @@
               listToAttrs (
                 map
                 (importKernel pkgs path kernels)
-                (attrNames getAvailableKernels path)
+                (attrNames (getAvailableKernels path))
               );
           };
       in rec {

--- a/flake.nix
+++ b/flake.nix
@@ -325,7 +325,7 @@
         and a path to a kernels directory, `path`,
         and returns a derivation for a JupyterLab environment.
         */
-        readKernelsFromPath = pkgs: path: let
+        mkJupyterEnvFromKernelPath = pkgs: path: let
           inherit (builtins) listToAttrs map attrNames;
         in
           mkJupyterlabInstance {
@@ -337,7 +337,7 @@
               );
           };
       in rec {
-        lib = {inherit readKernelsFromPath;};
+        lib = {inherit mkJupyterEnvFromKernelPath;};
         packages = {inherit jupyterlab example_jupyterlab;};
         packages.default = packages.jupyterlab;
         devShell = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -364,6 +364,7 @@
       defaultTemplate = {
         path = ./template;
         description = "Boilerplate for your jupyter-nix project";
+        welcomeText = builtins.readFile ./template/README.md;
       };
     };
 }

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,28 @@
+# Simple JupyterLab Environment Template
+
+## Getting started
+
+1. Create a new project folder and `cd` into it.
+
+```shell
+$ mkdir my-project
+$ cd my-project
+```
+
+2. Initialize the project with the jupyterWith flake template.
+
+```shell
+$ nix flake init --template github:tweag/jupyterWith
+```
+
+3. Kernels are located in the `kernels` directory. Kernels files that start
+an underscore are disabled and will not appear in JupyterLab. Remove the
+underscore from the file name to enable a kernel.
+
+4. Start the JupyterLab environment.
+
+```shell
+$ nix run
+```
+
+5. The environment should start up with instructions on what to do next.

--- a/template/default.nix
+++ b/template/default.nix
@@ -1,8 +1,14 @@
-{fromGit ? true}:
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src =
-    if fromGit
-    then builtins.fetchGit ./.
-    else ./.;
-})
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
 .defaultNix

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -18,10 +18,10 @@
     flake-utils.lib.eachSystem ["x86_64-linux"]
     (
       system: let
-        inherit (jupyterWith.lib.${system}) readKernelsFromPath;
+        inherit (jupyterWith.lib.${system}) mkJupyterEnvFromKernelPath;
 
         pkgs = import nixpkgs {inherit system;};
-        jupyterEnvironment = readKernelsFromPath pkgs ./kernels;
+        jupyterEnvironment = mkJupyterEnvFromKernelPath pkgs ./kernels;
       in rec {
         packages = {inherit jupyterEnvironment;};
         packages.default = jupyterEnvironment;

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -2,10 +2,10 @@
   description = "Your jupyterWith project";
 
   inputs.nixpkgs.follows = "jupyterWith/nixpkgs";
+  inputs.flake-compat.url = "github:edolstra/flake-compat";
+  inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.jupyterWith.url = "github:tweag/jupyterWith";
-
-  # inputs.jupyterWith.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {
     self,
@@ -13,27 +13,58 @@
     flake-utils,
     jupyterWith,
   }:
+  # TODO - Update Linux first and then MacOS when it is working.
     flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+      inherit (jupyterWith.lib.${system}) mkKernel mkJupyterlabInstance;
+
       pkgs = import nixpkgs {
         inherit system;
-        overlays = builtins.attrValues jupyterWith.overlays;
+        overlays = [
+          self.overlays.default
+          jupyterWith.overlays
+        ];
       };
 
       kernels = let
         inherit (builtins) map readDir attrNames;
         inherit (pkgs.lib.attrsets) filterAttrs;
         inherit (pkgs.lib.strings) hasPrefix hasSuffix;
+
+        /*
+        Takes a file name, `name` and a file type, `value`, and returns a
+        boolean if the file is meant to be an available kernel. Kernels whose
+        file names are prefixed with an underscore are meant to be hidden.
+        Useful for filtering the output of `readDir`.
+        */
+        filterAvailableKernels = name: value:
+          (value == "regular")
+          && hasSuffix ".nix" name
+          && !hasPrefix "_" name;
+
+        /*
+        Gets the available kernels as a set from the kernels directory. Name is
+        the kernel name and value is the file type.
+        */
+        getAvailableKernels =
+          filterAttrs
+          filterAvailableKernels
+          (readDir ./kernels);
+
+        /*
+        Takes a kernel name, `name`, and imports it from the kernels directory.
+        */
+        importKernel = name:
+          import ./kernels/${name} {inherit pkgs;};
       in
-        map (name: import ./kernels/${name} {inherit pkgs;})
-        (attrNames
-          (filterAttrs
-            (n: v: v == "regular" && hasSuffix ".nix" n && !hasPrefix "_" n)
-            (readDir ./kernels)));
+        map importKernel (attrNames getAvailableKernels);
 
       jupyterEnvironment =
         pkgs.jupyterWith.jupyterlabWith {inherit kernels;};
     in rec {
       defaultPackage = packages.jupyterEnvironment;
       packages = {inherit jupyterEnvironment;};
-    });
+    })
+    // {
+      overlays.default = final: prev: {};
+    };
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -52,16 +52,20 @@
           (readDir ./kernels);
 
         /*
-        Takes a kernel name, `name`, and imports it from the kernels directory.
+        Takes set of kernels, `kernels`, and a kernel name, `name`,
+        and imports it from the kernels directory.
+        Returns the imported kernels as the value of an attribute set.
         */
-        importKernel = name:
-          import ./kernels/${name} {inherit pkgs;};
+        importKernel = kernels: name: {
+          name = removeSuffix ".nix" name;
+          value = import ./kernels/${name} {inherit pkgs name mkKernel kernels;};
+        };
       in
         mkJupyterlabInstance {
           kernels = kernels:
             listToAttrs (
               map
-              importKernel
+              (importKernel kernels)
               (attrNames getAvailableKernels)
             );
         };

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -25,8 +25,8 @@
         ];
       };
 
-      kernels = let
-        inherit (builtins) map readDir attrNames;
+      jupyterEnvironment = let
+        inherit (builtins) listToAttrs map readDir attrNames;
         inherit (pkgs.lib.attrsets) filterAttrs;
         inherit (pkgs.lib.strings) hasPrefix hasSuffix;
 
@@ -56,13 +56,17 @@
         importKernel = name:
           import ./kernels/${name} {inherit pkgs;};
       in
-        map importKernel (attrNames getAvailableKernels);
-
-      jupyterEnvironment =
-        pkgs.jupyterWith.jupyterlabWith {inherit kernels;};
+        mkJupyterlabInstance {
+          kernels = kernels:
+            listToAttrs (
+              map
+              importKernel
+              (attrNames getAvailableKernels)
+            );
+        };
     in rec {
-      defaultPackage = packages.jupyterEnvironment;
       packages = {inherit jupyterEnvironment;};
+      packages.default = jupyterEnvironment;
     })
     // {
       overlays.default = final: prev: {};

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -72,6 +72,8 @@
     in rec {
       packages = {inherit jupyterEnvironment;};
       packages.default = jupyterEnvironment;
+      apps.default.program = "${jupyterEnvironment}/bin/jupyter-lab";
+      apps.default.type = "app";
     })
     // {
       overlays.default = final: prev: {};

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -10,6 +10,7 @@
   outputs = {
     self,
     nixpkgs,
+    flake-compat,
     flake-utils,
     jupyterWith,
   }:

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -22,12 +22,12 @@
         inherit system;
         overlays = [
           self.overlays.default
-          jupyterWith.overlays
         ];
       };
 
       jupyterEnvironment = let
         inherit (builtins) listToAttrs map readDir attrNames;
+        inherit (pkgs.lib) removeSuffix;
         inherit (pkgs.lib.attrsets) filterAttrs;
         inherit (pkgs.lib.strings) hasPrefix hasSuffix;
 

--- a/template/kernels/ihaskell.nix
+++ b/template/kernels/ihaskell.nix
@@ -1,7 +1,0 @@
-{pkgs}:
-pkgs.jupyterWith.kernels.iHaskellWith {
-  name = "ihaskell-flake";
-  packages = p: with p; [vector aeson];
-  extraIHaskellFlags = "--codemirror Haskell"; # for jupyterlab syntax highlighting
-  haskellPackages = pkgs.haskellPackages;
-}

--- a/template/kernels/ipython.nix
+++ b/template/kernels/ipython.nix
@@ -1,8 +1,9 @@
-{pkgs}:
-pkgs.jupyterWith.kernels.iPythonWith {
-  name = "Python-data-env";
-  ignoreCollisions = true;
-  packages = p: [
-    p.numpy
-  ];
+{
+  mkKernel,
+  kernels,
+  name,
+  ...
+}:
+mkKernel kernels.ipython {
+  displayName = name;
 }

--- a/template/shell.nix
+++ b/template/shell.nix
@@ -1,4 +1,14 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = ./.;
-})
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
 .shellNix


### PR DESCRIPTION
Updates the template flake, default, and shell files.
Removes the haskell kernel for now. Focusing on the python kernel.
To test, change the flake inputs url for jupyterWith to pull from `main` until it becomes the default branch.