### PR TITLE
Added julia to wrapped jupyterlab env if julia kernel is present.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -323,6 +323,17 @@
                 --set IPYTHONDIR "/path-not-set" \
                 --set JUPYTER_RUNTIME_DIR "/path-not-set"
             done
+
+            # add Julia for IJulia
+            allKernelPaths=${lib.concatStringsSep ":" kernelDerivations}
+            if [[ $allKernelPaths = *julia* ]]
+            then
+              echo 'Adding Julia as an available package.'
+              for i in ${pkgs.julia_17-bin}/bin/*; do
+                filename=$(basename $i)
+                ln -s ${pkgs.julia_17-bin}/bin/$filename $out/bin/$filename
+              done
+            fi
           '';
 
         kernels = {


### PR DESCRIPTION
Makes Julia available after running `nix build .#jupyterlab-all-kernels` or `nix build .#jupyterlab-kernel-julia`. Will not add Julia to the build if the IJulia kernel is not present. Useful for CI.