### PR TITLE
Next feature/fix mdformat ci

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,7 @@
               enable = true;
               name = "mdformat";
               description = "An opinionated Markdown formatter";
-              entry = "mdformat .";
+              entry = "${jupyterlab}/bin/mdformat .";
               types = ["file" "text" "markdown"];
             };
           };
@@ -490,7 +490,6 @@
           packages = [
             pkgs.alejandra
             pkgs.typos
-            jupyterlab
             poetry2nix.defaultPackage.${system}
             pkgs.python3Packages.poetry
             self.packages."${system}".update-poetry-lock

--- a/template/README.md
+++ b/template/README.md
@@ -66,7 +66,7 @@ my-project/
 
 1. The first step is to create a directory to put our new kernel which I named `custom-python`.
 
-2. The easiest way to create the `pyproject.toml` file is to copy it from the existing kernel in the repository. I have copied the Python kernels `pyproject.toml` file and added a `numpy` dependency under `tool.poetry.dependencies`.
+1. The easiest way to create the `pyproject.toml` file is to copy it from the existing kernel in the repository. I have copied the Python kernels `pyproject.toml` file and added a `numpy` dependency under `tool.poetry.dependencies`.
 
 ```toml
 [tool.poetry]
@@ -89,9 +89,9 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 ```
 
-3. Generate a `poetry.lock` file by running `poetry lock` in the kernel directory, `custom-python`.
+1. Generate a `poetry.lock` file by running `poetry lock` in the kernel directory, `custom-python`.
 
-4. Below is the `default.nix` file which looks similar to the file in the [previous example](#extending-kernels). However now we are overriding the `projectDir` attribute of the available kernel and setting it to the current directory. This tells `poetry2nix` to look in the current directory for the `pyproject.toml` and `poetry.lock` files which will create a new Python kernel with the version of `numpy` that we specified. Similar to before we override the `name` and `displayName` attribute so we can distinguish it from other kernels.
+1. Below is the `default.nix` file which looks similar to the file in the [previous example](#extending-kernels). However now we are overriding the `projectDir` attribute of the available kernel and setting it to the current directory. This tells `poetry2nix` to look in the current directory for the `pyproject.toml` and `poetry.lock` files which will create a new Python kernel with the version of `numpy` that we specified. Similar to before we override the `name` and `displayName` attribute so we can distinguish it from other kernels.
 
 ```nix
 {
@@ -106,7 +106,7 @@ availableKernels.python.override {
 }
 ```
 
-5. From the project top level directory, run `nix run`. This make take some time as new packages and dependencies have to be fetched. Eventually, you will see the recognizable messages from JupyterLab in your terminal. Open up the Web UI in your browser and use your custom kernel.
+1. From the project top level directory, run `nix run`. This make take some time as new packages and dependencies have to be fetched. Eventually, you will see the recognizable messages from JupyterLab in your terminal. Open up the Web UI in your browser and use your custom kernel.
 
 ### Custom Kernels
 


### PR DESCRIPTION
Fixed `nix flake check` failing in CI because `mdformat` was not found.
Having `jupyterlab` available in the devShell allows `pre-commit run -a` to work locally but not in CI. Fixed by updating the `pre-commit` hooks.