### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The following snippet will create a new project directory, initialize the projec
 mkdir my-project
 cd my-project
 nix flake init --template github:tweag/jupyterWith
-cp kernels/_python.nix kernels/my-python.nix
 nix run
 ```
 


### PR DESCRIPTION
The `kernels/_python.nix` file doesn't exist in the template. It's called `kernels/python.nix`.

Signed-off-by: Matthias Meschede <MMesch@users.noreply.github.com>