### PR TITLE
Get extraPackages (eg matplotlib) working

### DIFF
--- a/kernels/available/python/default.nix
+++ b/kernels/available/python/default.nix
@@ -7,7 +7,7 @@
   projectDir ? self + "/kernels/available/python",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? import ./overrides.nix pkgs,
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],

--- a/kernels/available/python/overrides.nix
+++ b/kernels/available/python/overrides.nix
@@ -1,1 +1,28 @@
-final: prev: {}
+pkgs: let
+  addNativeBuildInputs = prev: drvName: inputs: {
+    "${drvName}" = prev.${drvName}.overridePythonAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or []) ++ inputs;
+    });
+  };
+
+  # A fix is on the way soon, https://github.com/nix-community/poetry2nix/pull/787
+  preOverlay = final: prev: {
+    babel = null;
+    Babel = null;
+    babel_ = prev.babel.overridePythonAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.setuptools];
+    });
+    pillow_ = prev.pillow;
+    matplotlib_ = prev.matplotlib;
+  };
+
+  postOverlay = final: prev:
+    {}
+    // {
+      babel = prev.babel_;
+      Babel = prev.babel_;
+      pillow = prev.pillow_;
+      matplotlib = prev.matplotlib_;
+    };
+in
+  (pkgs.poetry2nix.defaultPoetryOverrides.overrideOverlay preOverlay).extend postOverlay

--- a/kernels/example_python.nix
+++ b/kernels/example_python.nix
@@ -7,4 +7,5 @@ availableKernels.python {
   inherit name;
   inherit (extraArgs) pkgs;
   displayName = "Example Python Kernel";
+  extraPackages = ps: with ps; [requests numpy matplotlib];
 }

--- a/kernels/example_stable_python.nix
+++ b/kernels/example_stable_python.nix
@@ -7,4 +7,5 @@ availableKernels.python {
   inherit name;
   pkgs = extraArgs.pkgs_stable;
   displayName = "Example (nixpkgs stable) Python Kernel";
+  extraPackages = ps: with ps; [requests numpy matplotlib];
 }


### PR DESCRIPTION
#338

The problem with matplotlib and probably other extraPackages is that they will clash with overrides from poetry2nix. Maybe we should not use it by default.

I'm not sure what the correct fix would be just yet (the one that has best ux), but I thought I would open PR to share my progress.