### PR TITLE
feature/use-self-for-kernel-arguments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -531,7 +531,7 @@
           )
         );
 
-        exampleJupyterlabAllKernels = mkJupyterlabFromPath ./kernels {inherit system;};
+        exampleJupyterlabAllKernels = mkJupyterlabFromPath ./kernels {inherit system pkgs_stable;};
 
         /*
         Returns kernel instance from a folder.

--- a/flake.nix
+++ b/flake.nix
@@ -165,10 +165,6 @@
       system: let
         overlays = [
           poetry2nix.overlay
-          rust-overlay.overlays.default
-          (self: super: {
-            npmlock2nix = pkgs.callPackage npmlock2nix {};
-          })
         ];
 
         pkgs = import nixpkgs {
@@ -525,7 +521,7 @@
                   kernels = availableKernels: [
                     (import kernelsConfig.kernels.${name} {
                       inherit name availableKernels;
-                      extraArgs = {inherit pkgs_stable;};
+                      extraArgs = {inherit system pkgs_stable;};
                     })
                   ];
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -180,7 +180,7 @@
         };
 
         baseArgs = {
-          inherit self pkgs;
+          inherit self system;
         };
 
         pre-commit = pre-commit-hooks.lib.${system}.run {
@@ -525,7 +525,7 @@
                   kernels = availableKernels: [
                     (import kernelsConfig.kernels.${name} {
                       inherit name availableKernels;
-                      extraArgs = {inherit pkgs pkgs_stable;};
+                      extraArgs = {inherit pkgs_stable;};
                     })
                   ];
                 };
@@ -535,7 +535,7 @@
           )
         );
 
-        exampleJupyterlabAllKernels = mkJupyterlabFromPath ./kernels {inherit pkgs pkgs_stable;};
+        exampleJupyterlabAllKernels = mkJupyterlabFromPath ./kernels {inherit system;};
 
         /*
         Returns kernel instance from a folder.

--- a/kernels/available/bash/default.nix
+++ b/kernels/available/bash/default.nix
@@ -1,21 +1,26 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "bash",
   displayName ? "Bash",
   runtimePackages ? with pkgs; [bashInteractive coreutils],
   extraRuntimePackages ? [],
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryPackages
   projectDir ? self + "/kernels/available/bash",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/available/c/default.nix
+++ b/kernels/available/c/default.nix
@@ -1,19 +1,24 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "c",
   displayName ? "C",
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryEnv
   projectDir ? self + "/kernels/available/c",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/available/elm/default.nix
+++ b/kernels/available/elm/default.nix
@@ -1,21 +1,26 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "elm",
   displayName ? "Elm",
   runtimePackages ? with pkgs.elmPackages; [elm],
   extraRuntimePackages ? [],
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryEnv
   projectDir ? self + "/kernels/available/elm",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject
@@ -52,6 +57,6 @@ in {
     "-f"
     "{connection_file}"
   ];
-  codemirrorMode = "yaml";
+  codemirrorMode = "elm";
   logo64 = ./logo64.png;
 }

--- a/kernels/available/go/default.nix
+++ b/kernels/available/go/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "go",
   displayName ? "Go",
   runtimePackages ? with pkgs; [go],

--- a/kernels/available/haskell/default.nix
+++ b/kernels/available/haskell/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "haskell",
   displayName ? "Haskell",
   ihaskell ? pkgs.haskellPackages.ihaskell,

--- a/kernels/available/javascript/default.nix
+++ b/kernels/available/javascript/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "javascript",
   displayName ? "Javascript",
   ijavascript ? pkgs.nodePackages.ijavascript,

--- a/kernels/available/julia/default.nix
+++ b/kernels/available/julia/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "julia",
   displayName ? "Julia",
   runtimePackages ? [],

--- a/kernels/available/nix/default.nix
+++ b/kernels/available/nix/default.nix
@@ -1,23 +1,28 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "nix",
   displayName ? "Nix",
   nix ? pkgs.nixVersions.stable,
   runtimePackages ? [nix],
   extraRuntimePackages ? [],
   nixpkgsPath ? pkgs.path,
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryPackages
   projectDir ? self + "/kernels/available/nix",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/available/ocaml/default.nix
+++ b/kernels/available/ocaml/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "ocaml",
   displayName ? "OCaml",
   runtimePackages ? [],

--- a/kernels/available/postgres/default.nix
+++ b/kernels/available/postgres/default.nix
@@ -1,21 +1,26 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "postgres",
   displayName ? "PostgreSQL",
   runtimePackages ? with pkgs; [postgresql],
   extraRuntimePackages ? [],
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryEnv
   projectDir ? self + "/kernels/available/postgres",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/available/python/default.nix
+++ b/kernels/available/python/default.nix
@@ -1,19 +1,24 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "python",
   displayName ? "Python3",
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryEnv
   projectDir ? self + "/kernels/available/python",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/available/r/default.nix
+++ b/kernels/available/r/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "r",
   displayName ? "R",
   rWrapper ? pkgs.rWrapper,

--- a/kernels/available/rust/default.nix
+++ b/kernels/available/rust/default.nix
@@ -1,6 +1,13 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ?
+    import self.inputs.nixpkgs {
+      inherit system;
+      overlays = [rust-overlay];
+    },
+  rust-overlay ? self.inputs.rust-overlay.overlays.default,
   name ? "rust",
   displayName ? "Rust",
   runtimePackages ? with pkgs; [cargo gcc binutils-unwrapped],

--- a/kernels/available/scala/default.nix
+++ b/kernels/available/scala/default.nix
@@ -1,6 +1,8 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "scala",
   displayName ? "Scala",
   runtimePackages ? [],

--- a/kernels/available/typescript/default.nix
+++ b/kernels/available/typescript/default.nix
@@ -19,7 +19,7 @@
     sha256 = "1q2wsdcgha6qivs238pysgmiabjhyflpd1bqbx0cgisgiz2nq3vs";
   };
 
-  tslab = pkgs.npmlock2nix.build {
+  tslab = npmlock2nix.build {
     src = tslabSrc;
     node_modules_attrs.packageLockJson = ./package-lock.json;
     buildInputs = [pkgs.makeWrapper];

--- a/kernels/available/typescript/default.nix
+++ b/kernels/available/typescript/default.nix
@@ -1,11 +1,13 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "typescript",
   displayName ? "Typescript",
   runtimePackages ? [],
   extraRuntimePackages ? [],
-  npmlock2nix ? pkgs.npmlock2nix,
+  npmlock2nix ? pkgs.callPackage self.inputs.npmlock2nix {},
 }: let
   inherit (pkgs) lib stdenv writeScriptBin;
   inherit (lib) makeBinPath;

--- a/kernels/available/zsh/default.nix
+++ b/kernels/available/zsh/default.nix
@@ -1,21 +1,26 @@
 {
   self,
-  pkgs,
+  system,
+  # custom arguments
+  pkgs ? self.inputs.nixpkgs.legacyPackages.${system},
   name ? "zsh",
   displayName ? "zsh",
   runtimePackages ? with pkgs; [zsh coreutils],
   extraRuntimePackages ? [],
+  # https://github.com/nix-community/poetry2nix
+  poetry2nix ? import "${self.inputs.poetry2nix}/default.nix" {inherit pkgs poetry;},
+  poetry ? pkgs.callPackage "${self.inputs.poetry2nix}/pkgs/poetry" {inherit python;},
   # https://github.com/nix-community/poetry2nix#mkPoetryPackages
   projectDir ? self + "/kernels/available/zsh",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env = pkgs.poetry2nix.mkPoetryEnv {
+  env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject

--- a/kernels/example_bash.nix
+++ b/kernels/example_bash.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.bash {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Bash Kernel";
 }

--- a/kernels/example_c.nix
+++ b/kernels/example_c.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.c {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example C Kernel";
 }

--- a/kernels/example_elm.nix
+++ b/kernels/example_elm.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.elm {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Elm Kernel";
 }

--- a/kernels/example_go.nix
+++ b/kernels/example_go.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.go {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Go Kernel";
 }

--- a/kernels/example_haskell.nix
+++ b/kernels/example_haskell.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.haskell {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Haskell Kernel";
 }

--- a/kernels/example_javascript.nix
+++ b/kernels/example_javascript.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.javascript {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Javascript Kernel";
 }

--- a/kernels/example_julia.nix
+++ b/kernels/example_julia.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.julia {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Julia Kernel";
 }

--- a/kernels/example_nix.nix
+++ b/kernels/example_nix.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.nix {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Nix Kernel";
 }

--- a/kernels/example_ocaml.nix
+++ b/kernels/example_ocaml.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.ocaml {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example OCaml Kernel";
 }

--- a/kernels/example_postgres.nix
+++ b/kernels/example_postgres.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.postgres {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Postgres Kernel";
 }

--- a/kernels/example_python.nix
+++ b/kernels/example_python.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.python {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Python Kernel";
 }

--- a/kernels/example_r.nix
+++ b/kernels/example_r.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.r {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example R Kernel";
 }

--- a/kernels/example_rust.nix
+++ b/kernels/example_rust.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.rust {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Rust Kernel";
 }

--- a/kernels/example_scala.nix
+++ b/kernels/example_scala.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.scala {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Scala Kernel";
 }

--- a/kernels/example_stable_python.nix
+++ b/kernels/example_stable_python.nix
@@ -5,6 +5,7 @@
 }:
 availableKernels.python {
   inherit name;
+  inherit (extraArgs) system;
   pkgs = extraArgs.pkgs_stable;
   displayName = "Example (nixpkgs stable) Python Kernel";
 }

--- a/kernels/example_typescript.nix
+++ b/kernels/example_typescript.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.typescript {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Typescript Kernel";
 }

--- a/kernels/example_zsh.nix
+++ b/kernels/example_zsh.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.zsh {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Example Zsh Kernel";
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -28,8 +28,7 @@
     (
       system: let
         inherit (jupyterWith.lib.${system}) mkJupyterlabFromPath;
-        pkgs = import nixpkgs {inherit system;};
-        jupyterlab = mkJupyterlabFromPath ./kernels {inherit pkgs;};
+        jupyterlab = mkJupyterlabFromPath ./kernels {inherit system;};
       in rec {
         packages = {inherit jupyterlab;};
         packages.default = jupyterlab;

--- a/template/kernels/python.nix
+++ b/template/kernels/python.nix
@@ -5,6 +5,6 @@
 }:
 availableKernels.python {
   inherit name;
-  inherit (extraArgs) pkgs;
+  inherit (extraArgs) system;
   displayName = "Custom ${name}";
 }


### PR DESCRIPTION
Removes the use of `pkgs` as a required argument for kernel definitions. `system` will now be a required argument and `pkgs` will be derived from self. This gives easier access for the end user to override the `pkgs` argument and removes the need for overlays.

As of right now, only the python kernel has been updated so all other kernels might fail.