### PR TITLE
Allow adding extra runtime packages

### DIFF
--- a/kernels/available/python/default.nix
+++ b/kernels/available/python/default.nix
@@ -12,7 +12,7 @@
   projectDir ? self + "/kernels/available/python",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? import ./overrides.nix,
+  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
   runtimePackages ?
@@ -24,19 +24,17 @@
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
-  env-overrides = poetry2nix.overrides.withDefaults overrides;
-
   env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject
       poetrylock
+      overrides
       python
       editablePackageSources
       extraPackages
       preferWheels
       ;
-    overrides = env-overrides;
   };
 
   allRuntimePackages = runtimePackages ++ extraRuntimePackages;

--- a/kernels/available/python/default.nix
+++ b/kernels/available/python/default.nix
@@ -12,23 +12,25 @@
   projectDir ? self + "/kernels/available/python",
   pyproject ? projectDir + "/pyproject.toml",
   poetrylock ? projectDir + "/poetry.lock",
-  overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
+  overrides ? import ./overrides.nix,
   python ? pkgs.python3,
   editablePackageSources ? {},
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let
+  env-overrides = poetry2nix.overrides.withDefaults overrides;
+
   env = poetry2nix.mkPoetryEnv {
     inherit
       projectDir
       pyproject
       poetrylock
-      overrides
       python
       editablePackageSources
       extraPackages
       preferWheels
       ;
+    overrides = env-overrides;
   };
 in {
   inherit name displayName;

--- a/kernels/available/python/default.nix
+++ b/kernels/available/python/default.nix
@@ -15,12 +15,8 @@
   overrides ? poetry2nix.overrides.withDefaults (import ./overrides.nix),
   python ? pkgs.python3,
   editablePackageSources ? {},
-  runtimePackages ?
-    with pkgs; [
-      bashInteractive
-      coreutils
-    ],
-  extraRuntimePackages ? with pkgs; [sox],
+  runtimePackages ? [],
+  extraRuntimePackages ? [],
   extraPackages ? ps: [],
   preferWheels ? false,
 }: let


### PR DESCRIPTION
With the change from this PR I can now have extra runtime dependencies passed to a Python kernel such as the dependencies are visible from the notebook.

![image](https://user-images.githubusercontent.com/1078000/203363397-9bbaf4b4-cfd4-4b1b-b777-3c3a4d8f2157.png)

The flake that produces the environment from where the screenshot was taken is https://git.sr.ht/~alejandrosame/voice-ast/tree/bfd8431b3ddd330a8d95a8883ebf7a780099a702/item/flake.nix 