### PR TITLE
Add a github token to the Nix config in the CI

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -11,6 +11,7 @@ runs:
       uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: cachix/cachix-action@v10
       with:


### PR DESCRIPTION
Should fix failures such as https://github.com/tweag/jupyterWith/actions/runs/3866231053/jobs/6590217205