### PR TITLE
Update flake lock and add new CI tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -278,16 +278,17 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1673211536,
-        "narHash": "sha256-I6VLdlTpWFwTI2iV9f7d5q05bnAQyXSJjCs2lwHmqWc=",
+        "lastModified": 1669990974,
+        "narHash": "sha256-wHhdlDUC/tBDVFBemeJPpqdIRdehKKbxbdMP0QjOhM4=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "bb3391b226b3b10a914103098bbe4cb972b4eeaa",
+        "rev": "75199758e1954f78286e7e79c0e3916e28b732b0",
         "type": "github"
       },
       "original": {
         "owner": "tweag",
         "repo": "opam-nix",
+        "rev": "75199758e1954f78286e7e79c0e3916e28b732b0",
         "type": "github"
       }
     },
@@ -310,11 +311,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1673100816,
-        "narHash": "sha256-v5E5ZymUpTE3ytxjs6vfiNsFCPGbWJviAnrk6q7SfbM=",
+        "lastModified": 1661161626,
+        "narHash": "sha256-J3P+mXLwE2oEKTlMnx8sYRxwD/uNGSKM0AkAB7BNTxA=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "9f576a1b9dd69b86bde542d9f89d534c0cc916b8",
+        "rev": "54e69ff0949a3aaec0d5e3d67898bb7f279ab09f",
         "type": "github"
       },
       "original": {
@@ -331,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "lastModified": 1665671715,
+        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -247,16 +247,17 @@
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1673447413,
-        "narHash": "sha256-sJM82Sj8yfQYs9axEmGZ9Evzdv/kDcI9sddqJ45frrU=",
+        "lastModified": 1668989938,
+        "narHash": "sha256-/IxdS0AiqSN0/VEOLnnfHyi4nP17yPrkhGf6KlXVwrc=",
         "owner": "nix-community",
         "repo": "npmlock2nix",
-        "rev": "9197bbf397d76059a76310523d45df10d2e4ca81",
+        "rev": "0ba0746d62974403daf717cded3f24c617622bc7",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "npmlock2nix",
+        "rev": "0ba0746d62974403daf717cded3f24c617622bc7",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668371230,
-        "narHash": "sha256-yGqXQj+swFEgOFa2CJn9oW/syFuMzZF9pyDQfxOYgT4=",
+        "lastModified": 1671426600,
+        "narHash": "sha256-MahAFyp6AxY0H61U6zqJXM1NsckNNkK6iqONEtOPSK0=",
         "owner": "ihaskell",
         "repo": "ihaskell",
-        "rev": "465fded2f705cedbc791d210508ca9febc04a208",
+        "rev": "1c22a874ac0c8ed019229f4a0cd5a0bfda017357",
         "type": "github"
       },
       "original": {
@@ -198,11 +198,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1669546925,
-        "narHash": "sha256-Gvtk9agz88tBgqmCdHl5U7gYttTkiuEd8/Rq1Im0pTg=",
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fecf05d4861f3985e8dee73f08bc82668ef75125",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
         "type": "github"
       },
       "original": {
@@ -214,27 +214,27 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1668984258,
-        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1673796341,
+        "narHash": "sha256-1kZi9OkukpNmOaPY7S5/+SlCDOuYnP3HkXHvNDyLQcc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "6dccdc458512abce8d19f74195bb20fdb067df50",
         "type": "github"
       },
       "original": {
@@ -247,11 +247,11 @@
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1668989938,
-        "narHash": "sha256-/IxdS0AiqSN0/VEOLnnfHyi4nP17yPrkhGf6KlXVwrc=",
+        "lastModified": 1673447413,
+        "narHash": "sha256-sJM82Sj8yfQYs9axEmGZ9Evzdv/kDcI9sddqJ45frrU=",
         "owner": "nix-community",
         "repo": "npmlock2nix",
-        "rev": "0ba0746d62974403daf717cded3f24c617622bc7",
+        "rev": "9197bbf397d76059a76310523d45df10d2e4ca81",
         "type": "github"
       },
       "original": {
@@ -277,16 +277,15 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1669980144,
-        "narHash": "sha256-1z9Lza41Ii30/Ljdeozoz7okm0+X+QyHilGjChzrZHo=",
+        "lastModified": 1673211536,
+        "narHash": "sha256-I6VLdlTpWFwTI2iV9f7d5q05bnAQyXSJjCs2lwHmqWc=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "a89f779c5b248c06136143e139848acae5d0ea49",
+        "rev": "bb3391b226b3b10a914103098bbe4cb972b4eeaa",
         "type": "github"
       },
       "original": {
         "owner": "tweag",
-        "ref": "fix-list-repo-func",
         "repo": "opam-nix",
         "type": "github"
       }
@@ -310,11 +309,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1661161626,
-        "narHash": "sha256-J3P+mXLwE2oEKTlMnx8sYRxwD/uNGSKM0AkAB7BNTxA=",
+        "lastModified": 1673100816,
+        "narHash": "sha256-v5E5ZymUpTE3ytxjs6vfiNsFCPGbWJviAnrk6q7SfbM=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "54e69ff0949a3aaec0d5e3d67898bb7f279ab09f",
+        "rev": "9f576a1b9dd69b86bde542d9f89d534c0cc916b8",
         "type": "github"
       },
       "original": {
@@ -331,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665671715,
-        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {
@@ -354,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669635649,
-        "narHash": "sha256-jGu5WoQrFLQBqT1BrwUtFsktzGkNoq9r6w6jwJdCpB8=",
+        "lastModified": 1673926875,
+        "narHash": "sha256-QOsT76Al0Igpo0u5vtQJuDSOxrocX3sTD523pLPEklc=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "ce8425ccc2884c1065927a38d1700024f431cf0f",
+        "rev": "a5c454a834cd290dd4d33102ab8b4aa37d850e65",
         "type": "github"
       },
       "original": {
@@ -407,11 +406,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1669152228,
-        "narHash": "sha256-FEDReoTLWJHXcNso7aaAlAUU7uOqIR6Hc/C/nqlfooE=",
+        "lastModified": 1674075316,
+        "narHash": "sha256-0uZuAcYBpNJLxr7n5O0vhwn3rSLpUTm9M5WGgmNQ+wM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "078b0dee35e2da01334af682ec347463b70a9986",
+        "rev": "3e42a77571cc0463efa470dbcffa063977a521ab",
         "type": "github"
       },
       "original": {
@@ -444,11 +443,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669602829,
-        "narHash": "sha256-I3LBvBiVui4Rf0iQvTqUIgBovaLDzpOzsoNEzCsDowg=",
+        "lastModified": 1674008920,
+        "narHash": "sha256-ugwPxKjvmJ5GpzN/MHg8tuhe8nYi3SbJm5nWNy7CB0Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b9da8e68a08707115be750c0cf7ade33f49d8ec4",
+        "rev": "eecc44934a0f6c02c02856b38bd3b6af3bec0870",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -192,14 +192,14 @@
             alejandra.enable = true;
             typos = {
               enable = true;
-              name = "typos";
-              description = "Source code spell checker";
-              entry = "${pkgs.typos}/bin/typos --write-changes --config _typos.toml";
               types = ["file"];
               files = "\\.((txt)|(md)|(nix)|\\d)$";
             };
           };
           excludes = ["^\\.jupyter/"]; # JUPYTERLAB_DIR
+          settings = {
+            typos.write = true;
+          };
         };
 
         mkdocs = python.withPackages (p: [

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
   inputs.ihaskell.inputs.flake-utils.follows = "flake-utils";
   inputs.npmlock2nix.url = "github:nix-community/npmlock2nix";
   inputs.npmlock2nix.flake = false;
-  inputs.opam-nix.url = "github:tweag/opam-nix/fix-list-repo-func";
+  inputs.opam-nix.url = "github:tweag/opam-nix";
   inputs.opam-nix.inputs.flake-compat.follows = "flake-compat";
   inputs.opam-nix.inputs.flake-utils.follows = "flake-utils";
   inputs.opam-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
   inputs.ihaskell.inputs.flake-utils.follows = "flake-utils";
   inputs.npmlock2nix.url = "github:nix-community/npmlock2nix/0ba0746d62974403daf717cded3f24c617622bc7";
   inputs.npmlock2nix.flake = false;
-  inputs.opam-nix.url = "github:tweag/opam-nix";
+  inputs.opam-nix.url = "github:tweag/opam-nix/75199758e1954f78286e7e79c0e3916e28b732b0";
   inputs.opam-nix.inputs.flake-compat.follows = "flake-compat";
   inputs.opam-nix.inputs.flake-utils.follows = "flake-utils";
   inputs.opam-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
   inputs.ihaskell.inputs.nixpkgs.follows = "nixpkgs";
   inputs.ihaskell.inputs.flake-compat.follows = "flake-compat";
   inputs.ihaskell.inputs.flake-utils.follows = "flake-utils";
-  inputs.npmlock2nix.url = "github:nix-community/npmlock2nix";
+  inputs.npmlock2nix.url = "github:nix-community/npmlock2nix/0ba0746d62974403daf717cded3f24c617622bc7";
   inputs.npmlock2nix.flake = false;
   inputs.opam-nix.url = "github:tweag/opam-nix";
   inputs.opam-nix.inputs.flake-compat.follows = "flake-compat";

--- a/kernels/available/typescript/default.nix
+++ b/kernels/available/typescript/default.nix
@@ -19,7 +19,7 @@
     sha256 = "1q2wsdcgha6qivs238pysgmiabjhyflpd1bqbx0cgisgiz2nq3vs";
   };
 
-  tslab = npmlock2nix.v2.build {
+  tslab = npmlock2nix.build {
     src = tslabSrc;
     node_modules_attrs.packageLockJson = ./package-lock.json;
     buildInputs = [pkgs.makeWrapper];

--- a/kernels/available/typescript/default.nix
+++ b/kernels/available/typescript/default.nix
@@ -19,7 +19,7 @@
     sha256 = "1q2wsdcgha6qivs238pysgmiabjhyflpd1bqbx0cgisgiz2nq3vs";
   };
 
-  tslab = npmlock2nix.build {
+  tslab = npmlock2nix.v2.build {
     src = tslabSrc;
     node_modules_attrs.packageLockJson = ./package-lock.json;
     buildInputs = [pkgs.makeWrapper];

--- a/kernels/example/python/science/default.nix
+++ b/kernels/example/python/science/default.nix
@@ -1,0 +1,11 @@
+{
+  availableKernels,
+  name,
+  extraArgs,
+}:
+availableKernels.python {
+  inherit name;
+  inherit (extraArgs) system;
+  displayName = "Example Python Kernel";
+  extraPackages = ps: [ps.numpy ps.scipy ps.matplotlib];
+}

--- a/kernels/example/python/science/test.ipynb
+++ b/kernels/example/python/science/test.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d13cad64-62c0-4b87-b8ef-0242658baa0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scipy as sp\n",
+    "import matplotlib as mpl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16f8a525-ab66-407d-b978-78af1ee27a4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(5)\n",
+    "print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97728667-fbc5-4e71-a3b7-52f174309b92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_new = sp.interpolate.interp1d(x, x ** 2)(x[:-1] + 0.5)\n",
+    "print(y_new)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d03e077a-add4-472f-afba-0c1f17e0159a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(mpl.colormaps['viridis'].resampled(8)(0.56))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Example Python Kernel",
+   "language": "python",
+   "name": "example-python-science"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/kernels/example/python/science/test.py
+++ b/kernels/example/python/science/test.py
@@ -1,0 +1,19 @@
+import os
+from testbook import testbook
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+@testbook(f'{current_dir}/test.ipynb', execute=True, kernel_name="example-python-science")
+def test_nb(tb):
+    np_result = tb.cell_output_text(1)
+    assert np_result == "[0 1 2 3 4]"
+
+    sp_result = tb.cell_output_text(2)
+    assert sp_result == "[ 0.5  2.5  6.5 12.5]"
+
+    mpl_result = tb.cell_output_text(3)
+    assert mpl_result == "(0.122312, 0.633153, 0.530398, 1.0)"
+
+if __name__ == '__main__':
+    test_nb()
+


### PR DESCRIPTION
Updates the top level flake inputs.
Addes a new python kernel example with `numpy`, `scipy`, and `matplotlib` to check that those packages work with the `extraPackages` argument.
Use new npmlock2nix v2 API.
Use new pre-commit API.