### PR TITLE
use `fetchCargoVendor`

### DIFF
--- a/lib/overrides.nix
+++ b/lib/overrides.nix
@@ -55,7 +55,7 @@ pkgs: let
         '';
       });
       rpds-py = prev.rpds-py.overridePythonAttrs (old: {
-        cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
+        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
           inherit (old) src;
           name = "${old.pname}-${old.version}";
           hash = "sha256-VOmMNEdKHrPKJzs+D735Y52y47MubPwLlfkvB7Glh14=";

--- a/modules/kernels/elm/overrides.nix
+++ b/modules/kernels/elm/overrides.nix
@@ -24,7 +24,7 @@ pkgs: let
       pypkgs-build-requirements)
     // {
       rpds-py = prev.rpds-py.overridePythonAttrs (old: {
-        cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
+        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
           inherit (old) src;
           name = "${old.pname}-${old.version}";
           hash = "sha256-VOmMNEdKHrPKJzs+D735Y52y47MubPwLlfkvB7Glh14=";


### PR DESCRIPTION
Should hopefully fix https://github.com/tweag/jupyenv/issues/571 and https://github.com/tweag/jupyenv/issues/570

Tests pass and the elm kernel seems to run fine